### PR TITLE
Updating Base-Image and Build-Deploy Script

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -22,5 +22,11 @@ DOCKER_CONFIG=$DOCKER_CONF docker login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 DOCKER_CONFIG=$DOCKER_CONF docker login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io
 DOCKER_CONFIG=$DOCKER_CONF docker build -t "${IMAGE}:${IMAGE_TAG}" .
 DOCKER_CONFIG=$DOCKER_CONF docker push "${IMAGE}:${IMAGE_TAG}"
-DOCKER_CONFIG=$DOCKER_CONF docker tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SMOKE_TEST_TAG}"
-DOCKER_CONFIG=$DOCKER_CONF docker push "${IMAGE}:${SMOKE_TEST_TAG}"
+
+if [[ $GIT_BRANCH == *"security-compliance"*]]; then
+    docker --config="$DOCKER_CONF" tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:security-compliance"
+    docker --config="$DOCKER_CONF" push "${IMAGE}:security-compliance"
+else
+    DOCKER_CONFIG=$DOCKER_CONF docker tag "${IMAGE}:${IMAGE_TAG}" "${IMAGE}:${SMOKE_TEST_TAG}"
+    DOCKER_CONFIG=$DOCKER_CONF docker push "${IMAGE}:${SMOKE_TEST_TAG}"
+fi


### PR DESCRIPTION
This PR is to update the `build-deploy.sh` script to support the `security-compliance` branch. Additionally, this update will be used to trigger the building of the `security-compliance` image. 