### PR TITLE
fixed getSystemsReport method for ROS systems report

### DIFF
--- a/src/server/data-access/rosDescriptor/index.ts
+++ b/src/server/data-access/rosDescriptor/index.ts
@@ -30,7 +30,7 @@ const getSystemsReport = async (
     ...params,
   };
 
-  const data = await axios.get(SYSTEMS_URL, {
+  const { data } = await axios.get(SYSTEMS_URL, {
     headers,
     params: defaultParams,
     paramsSerializer: (params) =>


### PR DESCRIPTION
This PR fixes the `generate` API for generating ROS systems report.