### PR TITLE
enable more easy development outside of EE

### DIFF
--- a/src/browser/puppeteerWorker.ts
+++ b/src/browser/puppeteerWorker.ts
@@ -73,7 +73,9 @@ const generatePdf = async ({
         }
       : {}),
 
-    'x-rh-identity': rhIdentity,
+    ...(config?.IS_DEVELOPMENT && !rhIdentity
+      ? {}
+      : { 'x-rh-identity': rhIdentity }),
   });
   const pageStatus = await page.goto(url, { waitUntil: 'networkidle2' });
   // get the error from DOM if it exists


### PR DESCRIPTION
As UIs are not yet completely ready to work in EE (e.g vuln, compliance), being able to work outside of EE helps us to run the server and use curl to test integration. But, if this violates our work requirements feel free to close the PR. 