### PR TITLE
[RHCLOUD-27148] Establish single execution queue for workerpool

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,20 @@ fetch('/api/crc-pdf-generator/v1/generate', {
   },
 
   body: JSON.stringify({
-    // service and template params are mandatory
-    service: 'ros',
-    template: 'executiveReport',
-    // ... any other config options accepted by your template
-  }),
-})
-  // If you are using fetch, don't forget to handle the response.ok === false branch before calling response.blob()!
-  .then((response) => response.blob())
+      // service and template params are mandatory
+      service: 'ros',
+      template: 'executiveReport',
+      // ... any other config options accepted by your template
+    }),
+  })
+  .then(async (response) => {
+    if (response.ok === false) {
+      const res = await response.json()
+      console.log(`PDF failed to generate: ${res.error.description}`)
+      throw new Error(`PDF failed to generate: ${res.error.description}`)
+    }
+    return response.blob()
+  })
   .then((blob) => {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -90,4 +96,4 @@ fetch('/api/crc-pdf-generator/v1/generate', {
 
 ```
 
-The PDF file will be downloaded b the browser.
+The PDF file will be downloaded in the browser.

--- a/src/browser/helpers.ts
+++ b/src/browser/helpers.ts
@@ -11,6 +11,8 @@ export const replaceString = (string: string) => {
   return string.replace(/[-[\]{}()'`*+?.,\\^$|#]/g, '\\$&');
 };
 
+export const MaxWorkers = 2;
+
 export const processOrientationOption = (
   request: Request<unknown, unknown, PreviewReqBody, PreviewReqQuery>
 ) => {

--- a/src/server/data-access/call-service.ts
+++ b/src/server/data-access/call-service.ts
@@ -45,6 +45,7 @@ function prepareServiceCall<T = Record<string, unknown>>(
     return (headers, options) =>
       Promise.resolve(descriptor.mock(headers, options));
   }
+
   const { service, path, responseProcessor, request } = descriptor || {};
   const serviceConfig = config?.endpoints[getServiceEndpointMap(service)];
   if (!config?.IS_DEVELOPMENT && !serviceConfig) {

--- a/src/server/data-access/index.ts
+++ b/src/server/data-access/index.ts
@@ -61,9 +61,7 @@ async function getTemplateData(
     );
     return data;
   } else {
-    throw new Error(
-      `No API descriptor available for ${templateConfig.service}: ${templateConfig.template}!`
-    );
+    throw `No API descriptor available for ${templateConfig.service}: ${templateConfig.template}!`;
   }
 }
 

--- a/src/server/workers.ts
+++ b/src/server/workers.ts
@@ -1,8 +1,15 @@
 import WP from 'workerpool';
+import { MaxWorkers } from '../browser/helpers';
+
+const createWorker = () => {
+  console.log(`New worker created`);
+};
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-call
 const pool = WP.pool('./dist/puppeteerWorker.js', {
-  maxWorkers: 12,
+  maxWorkers: MaxWorkers,
   workerType: 'process',
+  onCreateWorker: createWorker,
 });
 
 export default pool;


### PR DESCRIPTION
In order to make sure we don't open 20 pages at once and OOM Kill our pods, we need to set up a queue system for PDF tasks. When `/generate` is called, that request is added to the queue. If the queue is free, the worker pool will immediately start the task. If the queue is not free, it waits for an opportunity. 

This does not currently rebuild the queue if the pod restarts nor does it handle any timeouts. 