### PR TITLE
Update status code for malformed requests

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -78,6 +78,9 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
           "403": {
             "$ref": "#/components/responses/Unauthorized"
           },
@@ -96,6 +99,16 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/Error403"
+            }
+          }
+        }
+      },
+      "BadRequest": {
+        "description": "Bad Request",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error400"
             }
           }
         }
@@ -120,6 +133,25 @@
           },
           "message": {
             "type": "string"
+          }
+        }
+      },
+      "Error400": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "status": {
+                "type": "string"
+              },
+              "statusText": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            }
           }
         }
       },

--- a/src/server/routes/routes.ts
+++ b/src/server/routes/routes.ts
@@ -158,13 +158,24 @@ router.post(
         }
       });
     } catch (error: any) {
-      res.status(500).send({
-        error: {
-          status: 500,
-          statusText: 'Internal server error',
-          description: `${error}`,
-        },
-      });
+      const errStr = `${error}`;
+      if (errStr.includes('No API descriptor')) {
+        res.status(400).send({
+          error: {
+            status: 400,
+            statusText: 'Bad Request',
+            description: `${error}`,
+          },
+        });
+      } else {
+        res.status(500).send({
+          error: {
+            status: 500,
+            statusText: 'Internal server error',
+            description: `${error}`,
+          },
+        });
+      }
       next(`There was an error while generating a report: ${error}`);
     } finally {
       // To handle the edge case where a pool terminates while the queue isn't empty,


### PR DESCRIPTION
When an incorrect template or service is used, the API returns a 500. We need to change this status to [400](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400) to indicate that the request is incorrect and the server is not responsible for the error. 