### PR TITLE
Remove identity header from cache

### DIFF
--- a/src/middleware/identity-middleware.ts
+++ b/src/middleware/identity-middleware.ts
@@ -11,9 +11,10 @@ const identityMiddleware: Handler = (req, _res, next) => {
       const identityObject = JSON.parse(
         Buffer.from(rhIdentity as string, 'base64').toString()
       );
-      apiLogger.debug(JSON.stringify(identityObject));
-      // We are using ACCOUNT_ID here because it maps to that in the console shape
-      // From the API token, the field matches the user.user_id field
+      apiLogger.debug(`Identity Header: ${JSON.stringify(identityObject)}`);
+      // We are using ACCOUNT_ID here because it matches the window's auth shape.
+      // The API Token uses `identity.user.user_id` and corresponds to `internal.account_id`
+      // in the window.
       const accountID = identityObject?.identity?.user?.user_id;
       httpContext.set(config?.IDENTITY_HEADER_KEY as string, rhIdentity);
       httpContext.set(config?.IDENTITY_CONTEXT_KEY as string, identityObject);

--- a/src/server/cache.ts
+++ b/src/server/cache.ts
@@ -28,6 +28,7 @@ export class ReportCache {
    * Create a SHA1 hash of the template to condense entry sizes
    */
   createCacheKey(cacheKeyObject: CacheKey) {
+    apiLogger.debug(`Request to hash : ${JSON.stringify(cacheKeyObject)}`);
     try {
       return crypto
         .createHash('sha1')

--- a/src/server/routes/routes.ts
+++ b/src/server/routes/routes.ts
@@ -97,14 +97,13 @@ router.post(
   `${config?.APIPrefix}/generate`,
   async (req: GenerateHandlerRequest, res, next) => {
     const pdfDetails = getPdfRequestBody(config, req);
+    const { rhIdentity: _, ...noIdentityHeader } = pdfDetails;
     const accountID = httpContext.get(config?.ACCOUNT_ID as string);
     const cacheKey = cache.createCacheKey({
-      request: pdfDetails,
+      request: noIdentityHeader,
       accountID: accountID,
     });
-    apiLogger.debug(
-      `Generated new key ${cacheKey} with Account ID ${accountID}`
-    );
+    apiLogger.debug(`Hashed key ${cacheKey} with Account ID ${accountID}`);
 
     // Check for a cached version of the pdf
     const filePath = cache.fetch(sanitizeInput(cacheKey));


### PR DESCRIPTION
* Explicitly remove the identity header from the request for caching. 
* Update debug logging and explain how account id mismatch