### PR TITLE
Make response spec for /status match the actual response

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -362,13 +362,15 @@
         "type": "object",
         "properties": {
           "status": {
-            "type": "string"
-          },
-          "filepath": {
-            "type": "string"
-          },
-          "storageLocation": {
-            "type": "string"
+            "type": "object",
+            "properties": {
+              "filepath": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
With this update to the spec of /status, the generated client works in API tests.