### PR TITLE
[RHCLOUD-31211] Ensure generating objects are updated in cache

### DIFF
--- a/src/browser/helpers.ts
+++ b/src/browser/helpers.ts
@@ -149,6 +149,10 @@ class PdfCache {
   public getItem(id: string): PdfEntry {
     return this.data[id];
   }
+
+  public deleteItem(id: string) {
+    delete this.data[id];
+  }
 }
 
 export default PdfCache;

--- a/src/common/kafka.ts
+++ b/src/common/kafka.ts
@@ -80,9 +80,9 @@ const KafkaClient = () => {
 };
 
 const pdfCache = PdfCache.getInstance();
+const kafka = KafkaClient();
 
 export async function produceMessage(topic: string, message: unknown) {
-  const kafka = KafkaClient();
   const producer = kafka.producer();
 
   await producer.connect();
@@ -95,9 +95,7 @@ export async function produceMessage(topic: string, message: unknown) {
 }
 
 export async function consumeMessages(topic: string) {
-  const kafka = KafkaClient();
   const consumer = kafka.consumer({ groupId: `pdf-gen-${os.hostname()}` });
-
   await consumer.connect();
   await consumer.subscribe({ topic: topic, fromBeginning: true });
 


### PR DESCRIPTION
Since the cache is shared between all pods, we need to ensure that `generating` PDFs are updated in the shared cache. 
* Fixes missing kafka updates for `generating` statuses
* Uses only one kafka client per pod instead of making one for every kafka call 😬 