### PR TITLE
[RHCLOUD-33391] Fix 404 bug and Update OpenAPI spec

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -83,9 +83,6 @@
           "202": {
             "$ref": "#/components/responses/GeneratingPdfId"
           },
-          "400": {
-            "$ref": "#/components/responses/BadRequest"
-          },
           "403": {
             "$ref": "#/components/responses/Unauthorized"
           },
@@ -347,10 +344,18 @@
         }
       },
       "PdfDetails": {
-        "type": "array",
-        "description": "Schema entry for the payload of creating a Pdf",
-        "items": {
-          "$ref": "#/components/schemas/PdfDetail"
+        "type": "object",
+        "required": [
+          "payload"
+        ],
+        "properties": {
+          "payload": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PdfDetail"
+            },
+            "description": "Schema entry for the payload of creating a Pdf"
+          }
         }
       },
       "PdfStatusId": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14002,15 +14002,15 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "22.11.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.11.0.tgz",
-      "integrity": "sha512-U5U0Dx5Tsd/ec39BmflhcSFIK9UnZxGQfyUzvQVHivt6gIi6RgJqYL9MJaU90OG6tTz65XqzN4wF0ZyDyY0NuA==",
+      "version": "22.11.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-22.11.2.tgz",
+      "integrity": "sha512-8fjdQSgW0sq7471ftca24J7sXK+jXZ7OW7Gx+NEBFNyXrcTiBfukEI46gNq6hiMhbLEDT30NeylK/1ZoPdlKSA==",
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "2.2.3",
         "cosmiconfig": "9.0.0",
         "devtools-protocol": "0.0.1299070",
-        "puppeteer-core": "22.11.0"
+        "puppeteer-core": "22.11.2"
       },
       "bin": {
         "puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -14031,15 +14031,15 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "22.11.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.11.0.tgz",
-      "integrity": "sha512-57YUjhRoSpZWg9lCssWsgzM1/X/1jQnkKbbspbeW0bhZTt3TD4WdNXEYI7KrFFnSvx21tyHhfWW0zlxzbwYSAA==",
+      "version": "22.11.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-22.11.2.tgz",
+      "integrity": "sha512-vQo+YDuePyvj+92Z9cdtxi/HalKf+k/R4tE80nGtQqJRNqU81eHaHkbVfnLszdaLlvwFF5tipnnSCzqWlEddtw==",
       "dependencies": {
         "@puppeteer/browsers": "2.2.3",
         "chromium-bidi": "0.5.23",
         "debug": "4.3.5",
         "devtools-protocol": "0.0.1299070",
-        "ws": "8.17.0"
+        "ws": "8.17.1"
       },
       "engines": {
         "node": ">=18"
@@ -17787,9 +17787,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.0.tgz",
-      "integrity": "sha512-uJq6108EgZMAl20KagGkzCKfMEjxmKvZHG7Tlq0Z6nOky7YF7aq4mOx6xK8TJ/i1LeK4Qus7INktacctDgY8Ow==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/src/browser/clusterTask.ts
+++ b/src/browser/clusterTask.ts
@@ -225,7 +225,7 @@ export const generatePdf = async (
     .then((filename) => {
       return filename;
     })
-    // TODO: This seems dumb
+    // Throw the error up to the calling generator
     .catch((error) => {
       throw error;
     });

--- a/src/common/objectStore.ts
+++ b/src/common/objectStore.ts
@@ -111,6 +111,10 @@ export const uploadPDF = async (id: string, path: string) => {
 export const downloadPDF = async (id: string) => {
   const bucket = config?.objectStore.buckets[0].name;
   const collection = PdfCache.getInstance().getCollection(id);
+  if (!collection) {
+    apiLogger.debug(`No collection found for ${id}`);
+    return '';
+  }
   const components = collection.components.map(
     (component) => `${component.componentId}.pdf`
   );
@@ -165,6 +169,6 @@ export const downloadPDF = async (id: string) => {
     return buffer;
   } catch (error) {
     apiLogger.debug(`Error downloading file: ${error}`);
-    throw error;
+    return '';
   }
 };


### PR DESCRIPTION
* Fixes the download 404 issue by check collection exists first
* Updates OpenAPI spec for payload to match the API types
* Removes 400 as an error code from `/v2/create` since we can't validate until runtime
* Removes dead code path on `v2/create` route