### PR TITLE
Adjust enum to be friendly to client generator

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -454,18 +454,21 @@
           }
         }
       },
-      "PdfStatus": {
-        "type": "object",
-        "description": "enum of all possible status types a Pdf can have",
-        "properties": {
-          "status": {
-            "type": "string",
-            "enum": [
+      "PdfStatusEnum": {
+        "type": "string",
+        "enum": [
               "Generating",
               "Generated",
               "Failed",
               "NotFound"
             ]
+      },
+      "PdfStatus": {
+        "type": "string",
+        "description": "enum of all possible status types a Pdf can have",
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/PdfStatusEnum"
           }
         }
       },


### PR DESCRIPTION
Once I changed the way the PdfStatus was defined, the generated client worked without deserialization issues. It seemed to have an issue with the Enum definition nested directly inside of PdfStatus.