### PR TITLE
[RHCLOUD-33471] Ensure PDF collections have a component for each payload item

### DIFF
--- a/src/browser/clusterTask.ts
+++ b/src/browser/clusterTask.ts
@@ -31,203 +31,192 @@ export const generatePdf = async (
     authCookie,
   }: PdfRequestBody,
   collectionId: string
-): Promise<string> => {
+): Promise<void> => {
   const pdfPath = getNewPdfName(componentId);
-  const createFilename = async (): Promise<string> => {
-    await cluster.queue(async ({ page }: { page: Page }) => {
-      await page.setViewport({ width: pageWidth, height: pageHeight });
-      const offsetSize = pdfCache.getTotalPagesForCollection(collectionId);
-      apiLogger.debug(`PDF offset by: ${offsetSize}`);
-      // Enables console logging in Headless mode - handy for debugging components
-      page.on('console', (msg) =>
-        apiLogger.info(`[Headless log] ${msg.text()}`)
+  await cluster.queue(async ({ page }: { page: Page }) => {
+    const updateMessage = {
+      status: PdfStatus.Generating,
+      filepath: '',
+      componentId: componentId,
+      collectionId,
+    };
+    UpdateStatus(updateMessage);
+    await page.setViewport({ width: pageWidth, height: pageHeight });
+    const offsetSize = pdfCache.getTotalPagesForCollection(collectionId);
+    apiLogger.debug(`PDF offset by: ${offsetSize}`);
+    // Enables console logging in Headless mode - handy for debugging components
+    page.on('console', (msg) => apiLogger.info(`[Headless log] ${msg.text()}`));
+
+    await setWindowProperty(
+      page,
+      'customPuppeteerParams',
+      JSON.stringify({
+        puppeteerParams: {
+          pageWidth,
+          pageHeight,
+        },
+      })
+    );
+
+    const extraHeaders: Record<string, string> = {};
+    if (identity) {
+      extraHeaders['x-rh-identity'] = identity;
+    }
+
+    if (fetchDataParams) {
+      extraHeaders[config?.OPTIONS_HEADER_NAME] =
+        JSON.stringify(fetchDataParams);
+    }
+
+    if (authHeader) {
+      extraHeaders[config.AUTHORIZATION_CONTEXT_KEY] = authHeader;
+    }
+
+    if (authCookie) {
+      await page.setCookie({
+        name: config.JWT_COOKIE_NAME,
+        value: authCookie,
+        // We might have to change the domain to match the proxy
+        domain: 'localhost',
+      });
+    }
+
+    await page.setExtraHTTPHeaders(extraHeaders);
+
+    const pageResponse = await page.goto(url, {
+      waitUntil: 'networkidle2',
+      timeout: BROWSER_TIMEOUT,
+    });
+    // wait for subsequent network requests to finish
+    await page.waitForNetworkIdle({
+      idleTime: 1000,
+    });
+    // because a cached response is a 3xx, puppeteer counts cache as an error
+    // so we don't use pageResponse.ok()
+    const pageStatus = pageResponse?.status();
+
+    // get the error from DOM if it exists
+    const error = await page.evaluate(() => {
+      const elem = document.getElementById('crc-pdf-generator-err');
+      if (elem) {
+        return elem.innerText;
+      }
+    });
+
+    // error happened during page rendering
+    if (error && error.length > 0) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let response: any;
+      try {
+        // error should be JSON
+        response = JSON.parse(error);
+        apiLogger.debug(response.data);
+      } catch {
+        // fallback to initial error value
+        response = error;
+        apiLogger.debug(`Page render error ${response}`);
+      }
+      const updated = {
+        collectionId,
+        status: PdfStatus.Failed,
+        filepath: '',
+        componentId: componentId,
+        error: response,
+      };
+      UpdateStatus(updated);
+      PdfCache.getInstance().invalidateCollection(collectionId, response);
+      throw new PdfGenerationError(
+        collectionId,
+        componentId,
+        `Page render error: ${response}`
       );
-
-      await setWindowProperty(
-        page,
-        'customPuppeteerParams',
-        JSON.stringify({
-          puppeteerParams: {
-            pageWidth,
-            pageHeight,
-          },
-        })
+    }
+    if (!pageStatus || !isValidPageResponse(pageStatus)) {
+      apiLogger.debug(`Page status: ${pageResponse?.statusText()}`);
+      const updated = {
+        collectionId,
+        status: PdfStatus.Failed,
+        filepath: '',
+        componentId: componentId,
+        error: pageResponse?.statusText() || 'Page status not found',
+      };
+      UpdateStatus(updated);
+      PdfCache.getInstance().invalidateCollection(
+        collectionId,
+        pageResponse?.statusText() || 'Page status not found'
       );
+      throw new PdfGenerationError(
+        collectionId,
+        componentId,
+        `Puppeteer error while loading the react app: ${pageResponse?.statusText()}`
+      );
+    }
 
-      const extraHeaders: Record<string, string> = {};
-      if (identity) {
-        extraHeaders['x-rh-identity'] = identity;
-      }
+    const { headerTemplate, footerTemplate } = getHeaderAndFooterTemplates();
+    // Pain.
+    await page.addStyleTag({
+      content: '.empty-page { page-break-after: always; visibility: hidden; }',
+    });
+    await page.evaluate((offsetSize) => {
+      Array.from({ length: offsetSize }).forEach(() => {
+        const emptyPage = document.createElement('div');
+        emptyPage.className = 'empty-page';
+        emptyPage.textContent = 'empty';
+        document.body.prepend(emptyPage);
+        return emptyPage;
+      });
+    }, offsetSize);
+    const pageRange = `${offsetSize + 1}-`;
 
-      if (fetchDataParams) {
-        extraHeaders[config?.OPTIONS_HEADER_NAME] =
-          JSON.stringify(fetchDataParams);
-      }
-
-      if (authHeader) {
-        extraHeaders[config.AUTHORIZATION_CONTEXT_KEY] = authHeader;
-      }
-
-      if (authCookie) {
-        await page.setCookie({
-          name: config.JWT_COOKIE_NAME,
-          value: authCookie,
-          // We might have to change the domain to match the proxy
-          domain: 'localhost',
-        });
-      }
-
-      await page.setExtraHTTPHeaders(extraHeaders);
-
-      const pageResponse = await page.goto(url, {
-        waitUntil: 'networkidle2',
+    try {
+      const buffer = await page.pdf({
+        path: pdfPath,
+        format: 'a4',
+        printBackground: true,
+        margin: {
+          top: '54px',
+          bottom: '54px',
+        },
+        displayHeaderFooter: true,
+        headerTemplate,
+        footerTemplate,
+        pageRanges: pageRange,
         timeout: BROWSER_TIMEOUT,
       });
-      // wait for subsequent network requests to finish
-      await page.waitForNetworkIdle({
-        idleTime: 1000,
+      await uploadPDF(componentId, pdfPath).catch((error: unknown) => {
+        apiLogger.error(`Failed to upload PDF: ${error}`);
       });
-      // because a cached response is a 3xx, puppeteer counts cache as an error
-      // so we don't use pageResponse.ok()
-      const pageStatus = pageResponse?.status();
-
-      // get the error from DOM if it exists
-      const error = await page.evaluate(() => {
-        const elem = document.getElementById('crc-pdf-generator-err');
-        if (elem) {
-          return elem.innerText;
-        }
-      });
-
-      // error happened during page rendering
-      if (error && error.length > 0) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let response: any;
-        try {
-          // error should be JSON
-          response = JSON.parse(error);
-          apiLogger.debug(response.data);
-        } catch {
-          // fallback to initial error value
-          response = error;
-          apiLogger.debug(`Page render error ${response}`);
-        }
-        const updated = {
-          collectionId,
-          status: PdfStatus.Failed,
-          filepath: '',
-          componentId: componentId,
-          error: response,
-        };
-        UpdateStatus(updated);
-        PdfCache.getInstance().invalidateCollection(collectionId, response);
-        throw new PdfGenerationError(
-          collectionId,
-          componentId,
-          `Page render error: ${response}`
-        );
-      }
-      if (!pageStatus || !isValidPageResponse(pageStatus)) {
-        apiLogger.debug(`Page status: ${pageResponse?.statusText()}`);
-        const updated = {
-          collectionId,
-          status: PdfStatus.Failed,
-          filepath: '',
-          componentId: componentId,
-          error: pageResponse?.statusText() || 'Page status not found',
-        };
-        UpdateStatus(updated);
-        PdfCache.getInstance().invalidateCollection(
-          collectionId,
-          pageResponse?.statusText() || 'Page status not found'
-        );
-        throw new PdfGenerationError(
-          collectionId,
-          componentId,
-          `Puppeteer error while loading the react app: ${pageResponse?.statusText()}`
-        );
-      }
-
-      const { headerTemplate, footerTemplate } = getHeaderAndFooterTemplates();
-      // Pain.
-      await page.addStyleTag({
-        content:
-          '.empty-page { page-break-after: always; visibility: hidden; }',
-      });
-      await page.evaluate((offsetSize) => {
-        Array.from({ length: offsetSize }).forEach(() => {
-          const emptyPage = document.createElement('div');
-          emptyPage.className = 'empty-page';
-          emptyPage.textContent = 'empty';
-          document.body.prepend(emptyPage);
-          return emptyPage;
-        });
-      }, offsetSize);
-      const pageRange = `${offsetSize + 1}-`;
-
-      try {
-        const buffer = await page.pdf({
-          path: pdfPath,
-          format: 'a4',
-          printBackground: true,
-          margin: {
-            top: '54px',
-            bottom: '54px',
-          },
-          displayHeaderFooter: true,
-          headerTemplate,
-          footerTemplate,
-          pageRanges: pageRange,
-          timeout: BROWSER_TIMEOUT,
-        });
-        uploadPDF(componentId, pdfPath).catch((error: unknown) => {
-          apiLogger.error(`Failed to upload PDF: ${error}`);
-        });
-        const pdfDoc = await PDFDocument.load(buffer);
-        const numPages = pdfDoc.getPages().length;
-        apiLogger.debug(`Generated PDF with ${numPages} pages`);
-        const updated = {
-          collectionId,
-          status: PdfStatus.Generated,
-          filepath: pdfPath,
-          componentId: componentId,
-          numPages: numPages,
-        };
-        UpdateStatus(updated);
-        pdfCache.verifyCollection(collectionId);
-      } catch (error: unknown) {
-        const updated = {
-          collectionId,
-          status: PdfStatus.Failed,
-          filepath: '',
-          componentId: componentId,
-          error: JSON.stringify(error),
-        };
-        UpdateStatus(updated);
-        PdfCache.getInstance().invalidateCollection(
-          collectionId,
-          JSON.stringify(error)
-        );
-        throw new PdfGenerationError(
-          collectionId,
-          componentId,
-          `Failed to print pdf: ${JSON.stringify(error)}`
-        );
-      } finally {
-        await page.close();
-      }
-    });
-
-    return pdfPath;
-  };
-
-  const filename = await createFilename()
-    .then((filename) => {
-      return filename;
-    })
-    // Throw the error up to the calling generator
-    .catch((error) => {
-      throw error;
-    });
-  return filename;
+      const pdfDoc = await PDFDocument.load(buffer);
+      const numPages = pdfDoc.getPages().length;
+      apiLogger.debug(`Generated PDF with ${numPages} pages`);
+      const updated = {
+        collectionId,
+        status: PdfStatus.Generated,
+        filepath: pdfPath,
+        componentId: componentId,
+        numPages: numPages,
+      };
+      UpdateStatus(updated);
+    } catch (error: unknown) {
+      const updated = {
+        collectionId,
+        status: PdfStatus.Failed,
+        filepath: '',
+        componentId: componentId,
+        error: JSON.stringify(error),
+      };
+      UpdateStatus(updated);
+      PdfCache.getInstance().invalidateCollection(
+        collectionId,
+        JSON.stringify(error)
+      );
+      throw new PdfGenerationError(
+        collectionId,
+        componentId,
+        `Failed to print pdf: ${JSON.stringify(error)}`
+      );
+    } finally {
+      await page.close();
+    }
+  });
 };

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -5,8 +5,8 @@ import PdfCache, { PDFComponent } from '../common/pdfCache';
 
 const pdfCache = PdfCache.getInstance();
 
-export const UpdateStatus = (updateMessage: PDFComponent) => {
-  produceMessage(UPDATE_TOPIC, updateMessage)
+export const UpdateStatus = async (updateMessage: PDFComponent) => {
+  await produceMessage(UPDATE_TOPIC, updateMessage)
     .then(() => {
       apiLogger.debug('Generating message sent');
     })
@@ -14,6 +14,7 @@ export const UpdateStatus = (updateMessage: PDFComponent) => {
       apiLogger.error(`Kafka message not sent: ${error}`);
     });
   pdfCache.addToCollection(updateMessage.collectionId, updateMessage);
+  pdfCache.verifyCollection(updateMessage.collectionId);
 };
 
 export const isValidPageResponse = (code: number) => {


### PR DESCRIPTION
* Adds an `expectedLength` to the collection to ensure that each PDF component is done before a collection is registered as `Generated`
* Removes some older `pdfPath` code from v1 to make less promise chains
* General tidying of the async and kafka messaging code

The root cause of the issue is triggered when the cluster is busy queueing work and slows down. In some cases, a generation request of two items in a payload could incorrectly represent the collection as being generated. If the polling mechanism checked when the 1st component was finished but the 2nd component had not started, the status would be incorrectly labeled as Generated when the 2nd component hadn't been queued to generate from the cluster. The `expectedLength` property now matches the payload length to ensure that a Generated collection contains all the components. 