### PR TITLE
Add missing field in PdfComponentGroup

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -415,6 +415,9 @@
               "$ref": "#/components/schemas/PdfComponent"
             }
           },
+	  "expectedLength": {
+            "type": "number"
+	  },
           "status": {
             "$ref": "#/components/schemas/PdfStatus"
           },


### PR DESCRIPTION
Automated tests were failing due to serialization/deserialization issues in the generated API client. This addresses the problem with the spec.