### PR TITLE
[RHCLOUD-33471] Fix OpenAPI spec

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -420,6 +420,10 @@
           },
           "error": {
             "type": "string"
+          },
+          "expectedLength": {
+            "type": "integer",
+            "format": "int64"
           }
         }
       },
@@ -457,11 +461,11 @@
       "PdfStatusEnum": {
         "type": "string",
         "enum": [
-              "Generating",
-              "Generated",
-              "Failed",
-              "NotFound"
-            ]
+          "Generating",
+          "Generated",
+          "Failed",
+          "NotFound"
+        ]
       },
       "PdfStatus": {
         "type": "string",


### PR DESCRIPTION
Update spec object to include optional `expectedLength`