### PR TITLE
[RHCLOUD-33471] Strictly enforce expected pages

### DIFF
--- a/src/common/pdfCache.ts
+++ b/src/common/pdfCache.ts
@@ -50,7 +50,7 @@ export type PdfCollection = {
 };
 export type PDFComponentGroup = {
   components: PDFComponent[];
-  expectedLength?: number;
+  expectedLength: number;
   status: PdfStatus;
   error?: string;
 };
@@ -88,6 +88,7 @@ class PdfCache {
       this.data[collectionId] = {
         components: [],
         status: PdfStatus.Generating,
+        expectedLength: 0,
       };
       // Only add cache cleaner once. The entire collection will only last
       // ENTRY_TIMEOUT hours
@@ -159,6 +160,7 @@ class PdfCache {
       this.data[collectionId] = {
         components: [],
         status: PdfStatus.Generating,
+        expectedLength: 0,
       };
       // Only add cache cleaner once. The entire collection will only last
       // ENTRY_TIMEOUT hours

--- a/src/server/routes/routes.ts
+++ b/src/server/routes/routes.ts
@@ -246,8 +246,8 @@ router.post(
 
 router.get(`${config?.APIPrefix}/v2/status/:statusID`, (req: Request, res) => {
   const ID = req.params.statusID;
+  pdfCache.verifyCollection(ID);
   try {
-    pdfCache.verifyCollection(ID);
     const status = pdfCache.getCollection(ID);
     apiLogger.debug(JSON.stringify(status));
     if (!status) {


### PR DESCRIPTION
In order to (hopefully) path the race condition, we will enforce the page length kept by the pdf cache.