### PR TITLE
Simplify PdfStatus and increase generator compat

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -457,23 +457,15 @@
           }
         }
       },
-      "PdfStatusEnum": {
+      "PdfStatus": {
         "type": "string",
-        "enum": [
+        "description": "enum of all possible status types a Pdf can have",
+	"enum": [
               "Generating",
               "Generated",
               "Failed",
               "NotFound"
             ]
-      },
-      "PdfStatus": {
-        "type": "string",
-        "description": "enum of all possible status types a Pdf can have",
-        "properties": {
-          "status": {
-            "$ref": "#/components/schemas/PdfStatusEnum"
-          }
-        }
       },
       "RenderedPdf": {
         "description": "Pdf stream returned as media type pdf",


### PR DESCRIPTION
Although the previous spec was passing validation, we discovered that the spec wasn't compatible with openapi codegen 7.7.0. There was an issue with the definition of PdfStatusEnum. This version should be more broadly compatible.