### PR TITLE
[RHCLOUD-33471] Use specific length for defaults

### DIFF
--- a/src/browser/clusterTask.ts
+++ b/src/browser/clusterTask.ts
@@ -40,7 +40,7 @@ export const generatePdf = async (
       componentId: componentId,
       collectionId,
     };
-    UpdateStatus(updateMessage);
+    await UpdateStatus(updateMessage);
     await page.setViewport({ width: pageWidth, height: pageHeight });
     const offsetSize = pdfCache.getTotalPagesForCollection(collectionId);
     apiLogger.debug(`PDF offset by: ${offsetSize}`);

--- a/src/common/pdfCache.spec.ts
+++ b/src/common/pdfCache.spec.ts
@@ -77,4 +77,22 @@ describe('Pdf Cache updates', () => {
     expect(noLen.components.length).toBe(1);
     expect(noLen.status).toBe(PdfStatus.Generating);
   });
+
+  it('should set the length properly when a collection has not been added directly', () => {
+    const notAdded: PDFComponent = {
+      status: PdfStatus.Generated,
+      filepath: 'blah',
+      collectionId: '2255a523-fc64-6e51-910a-b1ff3918b440',
+      componentId: '11aaaaa-4cdc-4200-afbf-479d904ee987',
+      numPages: 5,
+    };
+    const compId = notAdded.collectionId;
+    pdfCache.setExpectedLength(compId, 2);
+    const added = pdfCache.getCollection(compId);
+    expect(added.components.length).toBe(0);
+    expect(added.status).toBe('Generating');
+    expect(added.expectedLength).toBe(2);
+    pdfCache.verifyCollection(compId);
+    expect(added.status).toBe('Generating');
+  });
 });

--- a/src/common/pdfCache.ts
+++ b/src/common/pdfCache.ts
@@ -160,7 +160,7 @@ class PdfCache {
       this.data[collectionId] = {
         components: [],
         status: PdfStatus.Generating,
-        expectedLength: 0,
+        expectedLength: length,
       };
       // Only add cache cleaner once. The entire collection will only last
       // ENTRY_TIMEOUT hours


### PR DESCRIPTION
* Default length of a collection should not be set to 0 when length is passed
* Await status update to ensure page numbers are accurate