### PR TITLE
[RHCLOUD-35271] Concurrently generate PDF slices

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -110,3 +110,6 @@ parameters:
 - description: Retention time span for pdf in MS (8 hours default)
   name: ENTRY_TIMEOUT
   value: "28800000"
+- description: Amount of worker threads that puppeteer-cluster will use
+  name: MAX_CONCURRENCY
+  value: 2

--- a/src/common/pdfCache.ts
+++ b/src/common/pdfCache.ts
@@ -154,8 +154,13 @@ class PdfCache {
     return [];
   }
 
-  // Function to sort PDFComponents by order
+  // Sort the components by their internal `order` and
+  // return the sorted components in ascending order
   private sortComponents(components: PDFComponent[]): PDFComponent[] {
+    // No point in sorting a slice of length 1
+    if (components.length < 2) {
+      return components;
+    }
     return components.slice().sort((a, b) => {
       const orderA = a.order || Number.MAX_VALUE;
       const orderB = b.order || Number.MAX_VALUE;
@@ -163,6 +168,7 @@ class PdfCache {
       return orderA - orderB;
     });
   }
+
   private updateCollectionState(
     collectionId: string,
     status: PdfStatus,

--- a/src/server/cluster.ts
+++ b/src/server/cluster.ts
@@ -7,9 +7,9 @@ import { CHROMIUM_PATH } from '../browser/helpers';
 export const GetPupCluster = async () => {
   const cluster = await Cluster.launch({
     concurrency: Cluster.CONCURRENCY_CONTEXT,
-    maxConcurrency: 1,
+    maxConcurrency: 3,
     // If a queued task fails, how many times will it retry before returning an error
-    retryLimit: 1,
+    retryLimit: 2,
     puppeteerOptions: {
       timeout: BROWSER_TIMEOUT,
       ...(config?.IS_PRODUCTION

--- a/src/server/cluster.ts
+++ b/src/server/cluster.ts
@@ -5,9 +5,10 @@ const BROWSER_TIMEOUT = 60_000;
 import { CHROMIUM_PATH } from '../browser/helpers';
 
 export const GetPupCluster = async () => {
+  const CONCURRENCY_DEFAULT = 2;
   const cluster = await Cluster.launch({
     concurrency: Cluster.CONCURRENCY_CONTEXT,
-    maxConcurrency: 3,
+    maxConcurrency: Number(process.env.MAX_CONCURRENCY) || CONCURRENCY_DEFAULT,
     // If a queued task fails, how many times will it retry before returning an error
     retryLimit: 2,
     puppeteerOptions: {

--- a/src/server/render-template/Footer.tsx
+++ b/src/server/render-template/Footer.tsx
@@ -1,10 +1,5 @@
 import FooterContainer from './FooterContainer';
-import PagesMarker from './PagesMaker';
 
-const Footer = () => (
-  <FooterContainer>
-    <PagesMarker />
-  </FooterContainer>
-);
+const Footer = () => <FooterContainer></FooterContainer>;
 
 export default Footer;

--- a/src/server/routes/routes.ts
+++ b/src/server/routes/routes.ts
@@ -188,30 +188,26 @@ router.post(
       ? req.body.payload
       : [req.body.payload];
 
+    const configHeaders: string | string[] | undefined =
+      req.headers[config?.OPTIONS_HEADER_NAME];
+    if (configHeaders) {
+      delete req.headers[config?.OPTIONS_HEADER_NAME];
+    }
+
     try {
       const requiredCalls = requestConfigs.length;
       if (requiredCalls === 1) {
         const pdfDetails = getPdfRequestBody(requestConfigs[0]);
-        const configHeaders: string | string[] | undefined =
-          req.headers[config?.OPTIONS_HEADER_NAME];
-        if (configHeaders) {
-          delete req.headers[config?.OPTIONS_HEADER_NAME];
-        }
         apiLogger.debug(`Single call to generator queued for ${collectionId}`);
         pdfCache.setExpectedLength(collectionId, requiredCalls);
-        generatePdf(pdfDetails, collectionId);
+        generatePdf(pdfDetails, collectionId, 1);
         return res.status(202).send({ statusID: collectionId });
       }
       pdfCache.setExpectedLength(collectionId, requiredCalls);
       apiLogger.debug(`Queueing ${requiredCalls} for ${collectionId}`);
       for (let x = 0; x < Number(requiredCalls); x++) {
         const pdfDetails = getPdfRequestBody(requestConfigs[x]);
-        const configHeaders: string | string[] | undefined =
-          req.headers[config?.OPTIONS_HEADER_NAME];
-        if (configHeaders) {
-          delete req.headers[config?.OPTIONS_HEADER_NAME];
-        }
-        generatePdf(pdfDetails, collectionId);
+        generatePdf(pdfDetails, collectionId, x + 1);
       }
 
       return res.status(202).send({ statusID: collectionId });

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -6,6 +6,7 @@ import PdfCache, { PDFComponent } from '../common/pdfCache';
 const pdfCache = PdfCache.getInstance();
 
 export const UpdateStatus = async (updateMessage: PDFComponent) => {
+  pdfCache.addToCollection(updateMessage.collectionId, updateMessage);
   await produceMessage(UPDATE_TOPIC, updateMessage)
     .then(() => {
       apiLogger.debug('Generating message sent');
@@ -13,7 +14,6 @@ export const UpdateStatus = async (updateMessage: PDFComponent) => {
     .catch((error: unknown) => {
       apiLogger.error(`Kafka message not sent: ${error}`);
     });
-  pdfCache.addToCollection(updateMessage.collectionId, updateMessage);
   pdfCache.verifyCollection(updateMessage.collectionId);
 };
 


### PR DESCRIPTION
Use the built in concurrency features to generate PDFs much faster

* Adds a `MAX_CONCURRENCY` env var to adjust the amount of workers
* Introduces an `order` field on each PDFComponent to reassemble the PDF slices in the correct order
* Removes adding page numbers at generation time and instead adds all page numbers to the final PDF
 