### PR TITLE
fix(error): Error handling to puppetteer and process failures

### DIFF
--- a/src/browser/clusterTask.ts
+++ b/src/browser/clusterTask.ts
@@ -34,184 +34,208 @@ export const generatePdf = async (
   order: number,
 ): Promise<void> => {
   const pdfPath = getNewPdfName(componentId);
-  await cluster.queue(async ({ page }: { page: Page }) => {
-    const updateMessage = {
-      status: PdfStatus.Generating,
-      filepath: '',
-      order: order,
-      componentId: componentId,
-      collectionId,
-    };
-    await UpdateStatus(updateMessage);
-    await page.setViewport({ width: pageWidth, height: pageHeight });
-    // Enables console logging in Headless mode - handy for debugging components
-    page.on('console', (msg) => apiLogger.info(`[Headless log] ${msg.text()}`));
-
-    await setWindowProperty(
-      page,
-      'customPuppeteerParams',
-      JSON.stringify({
-        puppeteerParams: {
-          pageWidth,
-          pageHeight,
-        },
-      }),
-    );
-
-    const extraHeaders: Record<string, string> = {};
-    if (identity) {
-      extraHeaders['x-rh-identity'] = identity;
-    }
-
-    if (fetchDataParams) {
-      extraHeaders[config?.OPTIONS_HEADER_NAME] =
-        JSON.stringify(fetchDataParams);
-    }
-
-    if (authHeader) {
-      extraHeaders[config.AUTHORIZATION_CONTEXT_KEY] = authHeader;
-    }
-
-    if (authCookie) {
-      await page.setCookie({
-        name: config.JWT_COOKIE_NAME,
-        value: authCookie,
-        // We might have to change the domain to match the proxy
-        domain: 'localhost',
-      });
-    }
-
-    await page.setExtraHTTPHeaders(extraHeaders);
-
-    const pageResponse = await page.goto(url, {
-      waitUntil: 'networkidle2',
-      timeout: BROWSER_TIMEOUT,
-    });
-    // wait for subsequent network requests to finish
-    await page.waitForNetworkIdle({
-      idleTime: 1000,
-    });
-    // because a cached response is a 3xx, puppeteer counts cache as an error
-    // so we don't use pageResponse.ok()
-    const pageStatus = pageResponse?.status();
-
-    // get the error from DOM if it exists
-    // check both the app-level error element and the template rendering error
-    const error = await page.evaluate(() => {
-      const appError = document.getElementById('crc-pdf-generator-err');
-      if (appError) {
-        return appError.innerText;
-      }
-      const templateError = document.getElementById('report-error');
-      if (templateError) {
-        return templateError.innerText;
-      }
-    });
-
-    // error happened during page rendering
-    if (error && error.length > 0) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      let response: any;
-      try {
-        // error should be JSON
-        response = JSON.parse(error);
-        apiLogger.debug(response.data);
-      } catch {
-        // fallback to initial error value
-        response = error;
-        apiLogger.debug(`Page render error ${response}`);
-      }
-      const updated = {
-        collectionId,
-        status: PdfStatus.Failed,
+  try {
+    await cluster.queue(async ({ page }: { page: Page }) => {
+      const updateMessage = {
+        status: PdfStatus.Generating,
         filepath: '',
-        componentId: componentId,
-        error: response,
         order: order,
-      };
-      UpdateStatus(updated);
-      PdfCache.getInstance().invalidateCollection(collectionId, response);
-      throw new PdfGenerationError(
-        collectionId,
-        componentId,
-        `Page render error: ${response}`,
-      );
-    }
-    if (!pageStatus || !isValidPageResponse(pageStatus)) {
-      apiLogger.debug(`Page status: ${pageResponse?.statusText()}`);
-      const updated = {
-        collectionId,
-        status: PdfStatus.Failed,
-        filepath: '',
         componentId: componentId,
-        order: order,
-        error: pageResponse?.statusText() || 'Page status not found',
+        collectionId,
       };
-      UpdateStatus(updated);
-      PdfCache.getInstance().invalidateCollection(
-        collectionId,
-        pageResponse?.statusText() || 'Page status not found',
+      await UpdateStatus(updateMessage);
+      await page.setViewport({ width: pageWidth, height: pageHeight });
+      // Enables console logging in Headless mode - handy for debugging components
+      page.on('console', (msg) =>
+        apiLogger.info(`[Headless log] ${msg.text()}`),
       );
-      throw new PdfGenerationError(
-        collectionId,
-        componentId,
-        `Puppeteer error while loading the react app: ${pageResponse?.statusText()}`,
+
+      await setWindowProperty(
+        page,
+        'customPuppeteerParams',
+        JSON.stringify({
+          puppeteerParams: {
+            pageWidth,
+            pageHeight,
+          },
+        }),
       );
-    }
 
-    const { headerTemplate, footerTemplate } = getHeaderAndFooterTemplates();
+      const extraHeaders: Record<string, string> = {};
+      if (identity) {
+        extraHeaders['x-rh-identity'] = identity;
+      }
 
-    try {
-      const buffer = await page.pdf({
-        path: pdfPath,
-        format: 'a4',
-        printBackground: true,
-        margin: {
-          top: '54px',
-          bottom: '54px',
-        },
-        landscape,
-        displayHeaderFooter: true,
-        headerTemplate,
-        footerTemplate,
+      if (fetchDataParams) {
+        extraHeaders[config?.OPTIONS_HEADER_NAME] =
+          JSON.stringify(fetchDataParams);
+      }
+
+      if (authHeader) {
+        extraHeaders[config.AUTHORIZATION_CONTEXT_KEY] = authHeader;
+      }
+
+      if (authCookie) {
+        await page.setCookie({
+          name: config.JWT_COOKIE_NAME,
+          value: authCookie,
+          // We might have to change the domain to match the proxy
+          domain: 'localhost',
+        });
+      }
+
+      await page.setExtraHTTPHeaders(extraHeaders);
+
+      const pageResponse = await page.goto(url, {
+        waitUntil: 'networkidle2',
         timeout: BROWSER_TIMEOUT,
       });
-      await store.uploadPDF(componentId, pdfPath).catch((error: unknown) => {
-        apiLogger.error(`Failed to upload PDF: ${error}`);
+      // wait for subsequent network requests to finish
+      await page.waitForNetworkIdle({
+        idleTime: 1000,
       });
-      const pdfDoc = await PDFDocument.load(buffer);
-      const numPages = pdfDoc.getPages().length;
-      apiLogger.debug(`Generated PDF with ${numPages} pages`);
-      const updated = {
-        collectionId,
-        status: PdfStatus.Generated,
-        filepath: pdfPath,
-        componentId: componentId,
-        numPages: numPages,
-        order: order,
-      };
-      UpdateStatus(updated);
-    } catch (error: unknown) {
-      const updated = {
-        collectionId,
-        status: PdfStatus.Failed,
-        filepath: '',
-        componentId: componentId,
-        order: order,
-        error: JSON.stringify(error),
-      };
-      UpdateStatus(updated);
-      PdfCache.getInstance().invalidateCollection(
-        collectionId,
-        JSON.stringify(error),
-      );
-      throw new PdfGenerationError(
-        collectionId,
-        componentId,
-        `Failed to print pdf: ${JSON.stringify(error)}`,
-      );
-    } finally {
-      await page.close();
-    }
-  });
+      // because a cached response is a 3xx, puppeteer counts cache as an error
+      // so we don't use pageResponse.ok()
+      const pageStatus = pageResponse?.status();
+
+      // get the error from DOM if it exists
+      // check both the app-level error element and the template rendering error
+      const error = await page.evaluate(() => {
+        const appError = document.getElementById('crc-pdf-generator-err');
+        if (appError) {
+          return appError.innerText;
+        }
+        const templateError = document.getElementById('report-error');
+        if (templateError) {
+          return templateError.innerText;
+        }
+      });
+
+      // error happened during page rendering
+      if (error && error.length > 0) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let response: any;
+        try {
+          // error should be JSON
+          response = JSON.parse(error);
+          apiLogger.debug(response.data);
+        } catch {
+          // fallback to initial error value
+          response = error;
+          apiLogger.debug(`Page render error ${response}`);
+        }
+        const updated = {
+          collectionId,
+          status: PdfStatus.Failed,
+          filepath: '',
+          componentId: componentId,
+          error: response,
+          order: order,
+        };
+        await UpdateStatus(updated);
+        PdfCache.getInstance().invalidateCollection(collectionId, response);
+        throw new PdfGenerationError(
+          collectionId,
+          componentId,
+          `Page render error: ${response}`,
+        );
+      }
+      if (!pageStatus || !isValidPageResponse(pageStatus)) {
+        apiLogger.debug(`Page status: ${pageResponse?.statusText()}`);
+        const updated = {
+          collectionId,
+          status: PdfStatus.Failed,
+          filepath: '',
+          componentId: componentId,
+          order: order,
+          error: pageResponse?.statusText() || 'Page status not found',
+        };
+        await UpdateStatus(updated);
+        PdfCache.getInstance().invalidateCollection(
+          collectionId,
+          pageResponse?.statusText() || 'Page status not found',
+        );
+        throw new PdfGenerationError(
+          collectionId,
+          componentId,
+          `Puppeteer error while loading the react app: ${pageResponse?.statusText()}`,
+        );
+      }
+
+      const { headerTemplate, footerTemplate } = getHeaderAndFooterTemplates();
+
+      try {
+        const buffer = await page.pdf({
+          path: pdfPath,
+          format: 'a4',
+          printBackground: true,
+          margin: {
+            top: '54px',
+            bottom: '54px',
+          },
+          landscape,
+          displayHeaderFooter: true,
+          headerTemplate,
+          footerTemplate,
+          timeout: BROWSER_TIMEOUT,
+        });
+        await store.uploadPDF(componentId, pdfPath).catch((error: unknown) => {
+          apiLogger.error(`Failed to upload PDF: ${error}`);
+        });
+        const pdfDoc = await PDFDocument.load(buffer);
+        const numPages = pdfDoc.getPages().length;
+        apiLogger.debug(`Generated PDF with ${numPages} pages`);
+        const updated = {
+          collectionId,
+          status: PdfStatus.Generated,
+          filepath: pdfPath,
+          componentId: componentId,
+          numPages: numPages,
+          order: order,
+        };
+        await UpdateStatus(updated);
+      } catch (error: unknown) {
+        const updated = {
+          collectionId,
+          status: PdfStatus.Failed,
+          filepath: '',
+          componentId: componentId,
+          order: order,
+          error: JSON.stringify(error),
+        };
+        await UpdateStatus(updated);
+        PdfCache.getInstance().invalidateCollection(
+          collectionId,
+          JSON.stringify(error),
+        );
+        throw new PdfGenerationError(
+          collectionId,
+          componentId,
+          `Failed to print pdf: ${JSON.stringify(error)}`,
+        );
+      } finally {
+        await page.close();
+      }
+    });
+  } catch (error: unknown) {
+    // Catch any errors that escape the cluster queue (e.g., cluster shutdown, browser crash)
+    // This prevents unhandled rejections when generatePdf is called without await
+    apiLogger.error(
+      `generatePdf outer catch for ${componentId}:`,
+      JSON.stringify(error),
+    );
+    const updated = {
+      collectionId,
+      status: PdfStatus.Failed,
+      filepath: '',
+      componentId: componentId,
+      order: order,
+      error: JSON.stringify(error),
+    };
+    await UpdateStatus(updated);
+    PdfCache.getInstance().invalidateCollection(
+      collectionId,
+      JSON.stringify(error),
+    );
+  }
 };

--- a/src/server/cluster.ts
+++ b/src/server/cluster.ts
@@ -35,6 +35,12 @@ export const GetPupCluster = async () => {
       ],
     },
   });
+
+  // Add error handlers to prevent unhandled rejections from cluster tasks
+  cluster.on('taskerror', (err: Error, data: unknown) => {
+    apiLogger.error('Puppeteer cluster task error:', err, 'data:', data);
+  });
+
   return cluster;
 };
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -41,6 +41,26 @@ const server = http.createServer({}, app).listen(PORT, () => {
 server.keepAliveTimeout = 60 * 1000 + 1000; // 61 s
 server.keepAliveTimeout = 60 * 1000 + 2000; // 62 s
 
+// Global error handlers to prevent crashes from unhandled rejections
+process.on(
+  'unhandledRejection',
+  (reason: unknown, promise: Promise<unknown>) => {
+    apiLogger.error('Unhandled Rejection at:', promise, 'reason:', reason);
+    // Don't exit in production - log and continue
+    // This prevents process crashes from async errors in PDF generation
+  },
+);
+
+process.on('uncaughtException', (error: Error) => {
+  apiLogger.error('Uncaught Exception:', error);
+  // Log the error but don't exit - let container orchestration handle restarts
+});
+
+// HTTP server error handler
+server.on('error', (error: Error) => {
+  apiLogger.error('HTTP Server error:', error);
+});
+
 const metricsApp = express();
 
 const metricsMiddleware = promBundle({

--- a/src/server/routes/routes.ts
+++ b/src/server/routes/routes.ts
@@ -234,7 +234,7 @@ router.post(
         collectionId: collectionId,
         componentId: '',
       };
-      UpdateStatus(updateMessage);
+      await UpdateStatus(updateMessage);
       res.status(500).send({
         error: {
           status: 500,

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -14,7 +14,7 @@ export const UpdateStatus = async (updateMessage: PDFComponent) => {
     .catch((error: unknown) => {
       apiLogger.error(`Kafka message not sent: ${error}`);
     });
-  pdfCache.verifyCollection(updateMessage.collectionId);
+  await pdfCache.verifyCollection(updateMessage.collectionId);
 };
 
 export const isValidPageResponse = (code: number) => {


### PR DESCRIPTION
Bot found various problems around error handling.

- missing awaits on functions, one of which is the generatePdf function.
- tradeoff on time waiting for that function - estimated ~1% by bot, validating.

1. Global Error Handlers (src/server/index.ts)                                                                                                                                                                                              
  - Added unhandledRejection, uncaughtException, and HTTP server error handlers
  - Prevents process crashes from async errors                                                                                                                                                                                                
                                                            
  2. Fixed Missing await Statements (5 locations)                                                                                                                                                                                             
  - src/server/utils.ts:17 - verifyCollection() now awaited                                                                                                                                                                                   
  - src/browser/clusterTask.ts - All 4 UpdateStatus() calls now awaited                                                                                                                                                                       
  - src/server/routes/routes.ts:237 - UpdateStatus() now awaited                                                                                                                                                                              
                                                                                                                                                                                                                                              
  3. Added Safety Wrapper (src/browser/clusterTask.ts)                                                                                                                                                                                        
  - Wrapped generatePdf() in try-catch to handle cluster errors                                                                                                                                                                               
  - Prevents unhandled rejections from Puppeteer timeouts/crashes                                                                                                                                                                             
                                                                                                                                                                                                                                              
  4. Cluster Error Handler (src/server/cluster.ts)                                                                                                                                                                                            
  - Added taskerror event listener for debugging