### PR TITLE
fix: add jsx/runtime to shared modules

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -92,6 +92,13 @@ const moduleFederationPlugin = new container.ModuleFederationPlugin({
       requiredVersion: '*',
       singleton: true,
     },
+    // Ensure react/jsx-runtime is in the webpack shared scope.
+    // Federated modules using the automatic JSX transform require it.
+    'react/jsx-runtime': {
+      requiredVersion: '*',
+      singleton: true,
+      eager: true,
+    },
     'react-router-dom': {
       requiredVersion: '*',
       singleton: true,


### PR DESCRIPTION
### Description

The JSX runtime was missing in the shared scoped causing unexpected runtime errors

[RHCLOUD-47486](https://redhat.atlassian.net/browse/RHCLOUD-47486)

---

### How to test locally

Need a module with automatic jsx runtime transformation and remove the import and singleton sharing to reproduce. Will fail even in the preview format. For example open browser over at:
```
http://localhost:8000/puppeteer?manifestLocation=%2Fapps%2Fvulnerability%2Ffed-mods.json&scope=vulnerability&module=.%2FExecutiveReport
```

---

### Anything reviewers should know?
Can't really test. Only with full e2e tests and a specific module

---

### Checklist
- NA Tests: new/updated tests cover the change
- [x] API: spec updated if endpoints changed (or N/A)
- [x] Migrations: backwards compatible if schema changed (or N/A)
- [x] Dependencies: no known impact to dependent services
- [x] Security: reviewed against [secure coding checklist](https://github.com/RedHatInsights/secure-coding-checklist) (or N/A)

### AI disclosure

It was only me :) 


[RHCLOUD-47486]: https://redhat.atlassian.net/browse/RHCLOUD-47486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ