### PR TITLE
fix: remove eager from shared modules jsx runtime

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -97,7 +97,6 @@ const moduleFederationPlugin = new container.ModuleFederationPlugin({
     'react/jsx-runtime': {
       requiredVersion: '*',
       singleton: true,
-      eager: true,
     },
     'react-router-dom': {
       requiredVersion: '*',

--- a/src/client/bootstrap.tsx
+++ b/src/client/bootstrap.tsx
@@ -11,6 +11,8 @@ import { createRoot } from 'react-dom/client';
 import { GeneratePayload } from '../common/types';
 import { ServiceNames, ServicesEndpoints } from '../integration/endpoints';
 
+import 'react/jsx-runtime';
+
 declare global {
   interface Window {
     __initialState__: GeneratePayload;


### PR DESCRIPTION
### Description
<!-- Summary of proposed changes: what and why. -->

[RHCLOUD-XXXXX](https://issues.redhat.com/browse/RHCLOUD-XXXXX)

---

### How to test locally
<!-- How can a reviewer exercise this? Special setup, env vars, seed data? -->
<!-- Bug fixes: how to reproduce the original bug and confirm the fix. -->

---

### Anything reviewers should know?
<!-- Trade-offs, performance considerations, pre/post merge actions required. -->

---

### Checklist
- [ ] Tests: new/updated tests cover the change
- [ ] API: spec updated if endpoints changed (or N/A)
- [ ] Migrations: backwards compatible if schema changed (or N/A)
- [ ] Dependencies: no known impact to dependent services
- [ ] Security: reviewed against [secure coding checklist](https://github.com/RedHatInsights/secure-coding-checklist) (or N/A)

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
