### PR TITLE
fix(config): multi deployment clowder endpoints

### DIFF
--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -5,10 +5,15 @@ import {
   KafkaBroker,
   KafkaTopic,
   Config,
+  Endpoint,
 } from 'app-common-js';
 import { UPDATE_TOPIC } from '../browser/constants';
 import * as fs from 'fs';
-import { ServiceNames, ServicesEndpoints } from '../integration/endpoints';
+import {
+  PREFERRED_CLOWDER_DEPLOYMENT_NAME_BY_SERVICE,
+  ServiceNames,
+  ServicesEndpoints,
+} from '../integration/endpoints';
 
 const defaultConfig: {
   webPort: number;
@@ -138,6 +143,49 @@ const defaultConfig: {
   ],
  */
 
+function pickClowderEndpointForApp(
+  rows: Endpoint[],
+  app: ServiceNames,
+): Endpoint {
+  if (rows.length <= 1) {
+    return rows[0];
+  }
+  const preferredName = PREFERRED_CLOWDER_DEPLOYMENT_NAME_BY_SERVICE[app];
+  if (preferredName) {
+    const match = rows.find((e) => e.name === preferredName);
+    if (match) {
+      return match;
+    }
+  }
+  return rows[rows.length - 1];
+}
+
+function mergeClowderDependencyEndpoints(
+  privateEndpoints: Endpoint[] | undefined,
+  publicEndpoints: Endpoint[] | undefined,
+  out: Partial<ServicesEndpoints>,
+) {
+  const byApp = new Map<string, Endpoint[]>();
+  const push = (endpoint: Endpoint) => {
+    const list = byApp.get(endpoint.app) ?? [];
+    list.push(endpoint);
+    byApp.set(endpoint.app, list);
+  };
+  privateEndpoints?.forEach(push);
+  publicEndpoints?.forEach(push);
+
+  byApp.forEach((rows, appKey) => {
+    const app = appKey as ServiceNames;
+    const resolvedEndpoint = pickClowderEndpointForApp(rows, app);
+    out[app] = {
+      app: resolvedEndpoint.app,
+      hostname: resolvedEndpoint.hostname,
+      name: resolvedEndpoint.name,
+      port: resolvedEndpoint.port,
+    };
+  });
+}
+
 function initializeConfig() {
   let isClowderEnabled = false;
   const endpoints: Partial<ServicesEndpoints> = {};
@@ -151,27 +199,14 @@ function initializeConfig() {
     isClowderEnabled = IsClowderEnabled();
     if (isClowderEnabled) {
       const clowderConfig = clowder.LoadedConfig();
-      if (clowderConfig.endpoints) {
-        try {
-          clowderConfig.privateEndpoints?.forEach((endpoint) => {
-            endpoints[endpoint.app as ServiceNames] = {
-              app: endpoint.app,
-              hostname: endpoint.hostname,
-              name: endpoint.name,
-              port: endpoint.port,
-            };
-          });
-        } catch (error) {
-          console.log('Could not parse privateEndpoints', error);
-        }
-        clowderConfig.endpoints.forEach((endpoint) => {
-          endpoints[endpoint.app as ServiceNames] = {
-            app: endpoint.app,
-            hostname: endpoint.hostname,
-            name: endpoint.name,
-            port: endpoint.port,
-          };
-        });
+      try {
+        mergeClowderDependencyEndpoints(
+          clowderConfig.privateEndpoints,
+          clowderConfig.endpoints,
+          endpoints,
+        );
+      } catch (error) {
+        console.log('Could not merge Clowder dependency endpoints', error);
       }
       if (clowderConfig.kafka.brokers[0].cacert != undefined) {
         try {

--- a/src/integration/endpoints.ts
+++ b/src/integration/endpoints.ts
@@ -12,3 +12,9 @@ export enum ServiceNames {
 export type ServicesEndpoints = {
   [key in ServiceNames]: Endpoint;
 };
+
+export const PREFERRED_CLOWDER_DEPLOYMENT_NAME_BY_SERVICE: Partial<
+  Record<ServiceNames, string>
+> = {
+  [ServiceNames['vulnerability-engine']]: 'manager-service',
+};


### PR DESCRIPTION
### Description

I'm trying to debug pdf-generator for vulnerability-ui in stage. Currently it half works but API reaches incorrect service [manager-admin-service](https://github.com/RedHatInsights/vulnerability-engine/blob/master/deploy/clowdapp.yaml#L126) which has no implemented endpoint and as the result we get 404. It should use [manager-service](https://github.com/RedHatInsights/vulnerability-engine/blob/master/deploy/clowdapp.yaml#L15C13-L15C20) instead. I think it happens because they might share the same app name and the last one (manager-admin-service) overrides the first one [here](https://github.com/RedHatInsights/pdf-generator/blob/main/src/common/config.ts#L167-L174).

Based on ACG file vulnerability-engine has two entries
"vulnerability-engine":{
  "manager-admin-service":{"uri":"http://vulnerability-engine-manager-admin-service.ephemeral-hfwnhp.svc:8000/"},
  "manager-service":{"uri":"http://vulnerability-engine-manager-service.ephemeral-hfwnhp.svc:8000/"}}}
}
so with the current config - it just picks one of these instead of using correct one. Because of that, pdf generator fails to generate PDF



### How to test locally
<!-- How can a reviewer exercise this? Special setup, env vars, seed data? -->
<!-- Bug fixes: how to reproduce the original bug and confirm the fix. -->

---

### Anything reviewers should know?
<!-- Trade-offs, performance considerations, pre/post merge actions required. -->

---

### Checklist
- [ ] Tests: new/updated tests cover the change
- [ ] API: spec updated if endpoints changed (or N/A)
- [ ] Migrations: backwards compatible if schema changed (or N/A)
- [ ] Dependencies: no known impact to dependent services
- [ ] Security: reviewed against [secure coding checklist](https://github.com/RedHatInsights/secure-coding-checklist) (or N/A)

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
