### PR TITLE
fix(config): multi deployment clowder endpoints

### DIFF
--- a/src/client/bootstrap.tsx
+++ b/src/client/bootstrap.tsx
@@ -9,14 +9,18 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { GeneratePayload } from '../common/types';
-import { ServiceNames, ServicesEndpoints } from '../integration/endpoints';
+import {
+  ServiceNames,
+  IntegrationEndpointsMap,
+} from '../integration/endpoints';
+import { resolveInternalRouteKey } from '../common/integrationEndpoints';
 
 import 'react/jsx-runtime';
 
 declare global {
   interface Window {
     __initialState__: GeneratePayload;
-    __endpoints__: Partial<ServicesEndpoints>;
+    __endpoints__: IntegrationEndpointsMap;
     IS_PRODUCTION: boolean;
   }
 }
@@ -36,30 +40,46 @@ const config: AppsConfig = {
   },
 };
 
+type CreateAxiosRequestConfig = AxiosRequestConfig & {
+  clowderDeploymentName?: string;
+};
+
 type CreateAxiosRequest = (
   service: ServiceNames,
-  config: AxiosRequestConfig,
+  config: CreateAxiosRequestConfig,
 ) => Promise<unknown>;
 
-function createAxiosRequest(service: ServiceNames, config: AxiosRequestConfig) {
-  if (window.IS_PRODUCTION && !window.__endpoints__[service]) {
-    const message = `createAxiosRequest: Service ${service} not found! Available services: ${Object.keys(
-      window.__endpoints__,
-    ).join(', ')}.\n You might need to add service integration in the config.`;
+const createAxiosRequest: CreateAxiosRequest = (service, config) => {
+  const { clowderDeploymentName, ...axiosConfig } = config;
+  const routeKey = resolveInternalRouteKey(
+    service,
+    window.__endpoints__,
+    clowderDeploymentName,
+  );
+
+  if (window.IS_PRODUCTION && !routeKey) {
+    const message = `createAxiosRequest: internal route for "${service}" not found${
+      clowderDeploymentName
+        ? ` (clowderDeploymentName: ${clowderDeploymentName})`
+        : ''
+    }. Known keys: ${Object.keys(window.__endpoints__).join(
+      ', ',
+    )}. For apps with multiple Clowder deployments pass clowderDeploymentName (e.g. manager-service).`;
     throw new Error(message);
   }
 
-  if (!config.url) {
+  if (!axiosConfig.url) {
     throw new Error('createAxiosRequest: URL is required!');
   }
-  config.url = `/internal/${service}${config.url}`;
-  return axios(config)
+  const resolvedKey = routeKey ?? service;
+  axiosConfig.url = `/internal/${resolvedKey}${axiosConfig.url}`;
+  return axios(axiosConfig)
     .then((response: AxiosResponse) => response.data)
     .catch((error) => {
       console.error(error);
       throw error;
     });
-}
+};
 
 type FetchData = (
   createAsyncRequest: CreateAxiosRequest,
@@ -106,6 +126,26 @@ const MetadataWrapper = () => {
         state.scope,
         state.module,
         'fetchData',
+      );
+      const fetchParams = state.fetchDataParams;
+      const fetchParamsRecord =
+        fetchParams &&
+        typeof fetchParams === 'object' &&
+        !Array.isArray(fetchParams)
+          ? fetchParams
+          : undefined;
+      console.log(
+        `[crc-pdf-generator] after getModule(fetchData): ${JSON.stringify({
+          module: state.module,
+          importName: state.importName,
+          hasFetchDataExport: Boolean(fn),
+          fetchDataParamKeys: fetchParamsRecord
+            ? Object.keys(fetchParamsRecord)
+            : [],
+          fetchDataParamsClowderDeploymentName:
+            fetchParamsRecord?.clowderDeploymentName ??
+            '(not on fetchDataParams)',
+        })}`,
       );
       if (!fn) {
         setAsyncState({ loading: false, error: null, data: null });

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -8,13 +8,14 @@ import {
 } from 'app-common-js';
 import { UPDATE_TOPIC } from '../browser/constants';
 import * as fs from 'fs';
-import { ServiceNames, ServicesEndpoints } from '../integration/endpoints';
+import { IntegrationEndpointsMap } from '../integration/endpoints';
+import { mergeClowderEndpoints } from './integrationEndpoints';
 
 const defaultConfig: {
   webPort: number;
   metricsPort: number;
   metricsPath: string;
-  endpoints: Partial<ServicesEndpoints>;
+  endpoints: IntegrationEndpointsMap;
   tlsCAPath: string;
   objectStore: {
     hostname: string;
@@ -140,7 +141,7 @@ const defaultConfig: {
 
 function initializeConfig() {
   let isClowderEnabled = false;
-  const endpoints: Partial<ServicesEndpoints> = {};
+  const endpoints: IntegrationEndpointsMap = {};
 
   try {
     let config: typeof defaultConfig = {
@@ -153,25 +154,16 @@ function initializeConfig() {
       const clowderConfig = clowder.LoadedConfig();
       if (clowderConfig.endpoints) {
         try {
-          clowderConfig.privateEndpoints?.forEach((endpoint) => {
-            endpoints[endpoint.app as ServiceNames] = {
-              app: endpoint.app,
-              hostname: endpoint.hostname,
-              name: endpoint.name,
-              port: endpoint.port,
-            };
-          });
+          Object.assign(
+            endpoints,
+            mergeClowderEndpoints(
+              clowderConfig.privateEndpoints,
+              clowderConfig.endpoints,
+            ),
+          );
         } catch (error) {
-          console.log('Could not parse privateEndpoints', error);
+          console.log('Could not merge Clowder endpoints', error);
         }
-        clowderConfig.endpoints.forEach((endpoint) => {
-          endpoints[endpoint.app as ServiceNames] = {
-            app: endpoint.app,
-            hostname: endpoint.hostname,
-            name: endpoint.name,
-            port: endpoint.port,
-          };
-        });
       }
       if (clowderConfig.kafka.brokers[0].cacert != undefined) {
         try {

--- a/src/common/integrationEndpoints.spec.ts
+++ b/src/common/integrationEndpoints.spec.ts
@@ -1,0 +1,185 @@
+import { Endpoint } from 'app-common-js';
+import { ServiceNames } from '../integration/endpoints';
+import {
+  mergeClowderEndpoints,
+  buildInternalRouteKey,
+  resolveInternalRouteKey,
+  rewriteInternalProxiedPath,
+} from './integrationEndpoints';
+
+const endpoint = (
+  partial: Partial<Endpoint> & Pick<Endpoint, 'app' | 'name'>,
+): Endpoint =>
+  ({
+    hostname: 'h.example.svc',
+    port: 8000,
+    tlsPort: 0,
+    ...partial,
+  }) as Endpoint;
+
+describe('mergeClowderEndpoints', () => {
+  it('returns empty map when there are no integrated endpoints', () => {
+    expect(
+      mergeClowderEndpoints(undefined, [
+        endpoint({ app: 'unknown-app', name: 'api' }),
+      ]),
+    ).toEqual({});
+  });
+
+  it('uses app as key when that app appears only once', () => {
+    const compliance = endpoint({
+      app: 'compliance',
+      name: 'service',
+      hostname: 'compliance-service.ns.svc',
+    });
+    expect(mergeClowderEndpoints(undefined, [compliance])).toEqual({
+      compliance: {
+        app: 'compliance',
+        hostname: 'compliance-service.ns.svc',
+        name: 'service',
+        port: 8000,
+      },
+    });
+  });
+
+  it('merges privateEndpoints before public and uses app-name keys when app repeats', () => {
+    const manager = endpoint({
+      app: 'vulnerability-engine',
+      name: 'manager-service',
+      hostname: 've-manager.ns.svc',
+    });
+    const admin = endpoint({
+      app: 'vulnerability-engine',
+      name: 'manager-admin-service',
+      hostname: 've-admin.ns.svc',
+    });
+    const privateRow = endpoint({
+      app: 'vulnerability-engine',
+      name: 'listener-service',
+      hostname: 've-listener.ns.svc',
+    });
+
+    const out = mergeClowderEndpoints([privateRow], [manager, admin]);
+
+    expect(Object.keys(out).sort()).toEqual([
+      'vulnerability-engine-listener-service',
+      'vulnerability-engine-manager-admin-service',
+      'vulnerability-engine-manager-service',
+    ]);
+    expect(out['vulnerability-engine-manager-service']?.hostname).toBe(
+      've-manager.ns.svc',
+    );
+  });
+
+  it('deduplicates same app and name across private and public lists', () => {
+    const privateRow = endpoint({
+      app: 'compliance',
+      name: 'service',
+      hostname: 'compliance-private.ns.svc',
+    });
+    const publicRow = endpoint({
+      app: 'compliance',
+      name: 'service',
+      hostname: 'compliance-public.ns.svc',
+    });
+    expect(mergeClowderEndpoints([privateRow], [publicRow])).toEqual({
+      compliance: {
+        app: 'compliance',
+        hostname: 'compliance-private.ns.svc',
+        name: 'service',
+        port: 8000,
+      },
+    });
+  });
+
+  it('uses app-name keys for distinct names across private and public lists', () => {
+    const a = endpoint({
+      app: 'ros-backend',
+      name: 'api',
+      hostname: 'ros-a.svc',
+    });
+    const b = endpoint({
+      app: 'ros-backend',
+      name: 'alt',
+      hostname: 'ros-b.svc',
+    });
+    expect(mergeClowderEndpoints([a], [b])).toEqual({
+      'ros-backend-api': {
+        app: 'ros-backend',
+        hostname: 'ros-a.svc',
+        name: 'api',
+        port: 8000,
+      },
+      'ros-backend-alt': {
+        app: 'ros-backend',
+        hostname: 'ros-b.svc',
+        name: 'alt',
+        port: 8000,
+      },
+    });
+  });
+});
+
+describe('resolveInternalRouteKey', () => {
+  it('falls back to plain service key when composite is missing', () => {
+    const endpoints = {
+      compliance: {
+        app: 'compliance',
+        hostname: 'c.svc',
+        name: 'service',
+        port: 8000,
+      },
+    };
+    expect(
+      resolveInternalRouteKey(ServiceNames.compliance, endpoints, 'service'),
+    ).toBe('compliance');
+  });
+
+  it('uses composite key when present', () => {
+    const endpoints = mergeClowderEndpoints(undefined, [
+      endpoint({ app: 'ros-backend', name: 'api', hostname: 'a.svc' }),
+      endpoint({ app: 'ros-backend', name: 'alt', hostname: 'b.svc' }),
+    ]);
+    expect(
+      resolveInternalRouteKey(ServiceNames['ros-backend'], endpoints, 'api'),
+    ).toBe('ros-backend-api');
+  });
+});
+
+describe('buildInternalRouteKey', () => {
+  it('appends deployment when clowderDeploymentName is set', () => {
+    expect(
+      buildInternalRouteKey(
+        ServiceNames['vulnerability-engine'],
+        'manager-service',
+      ),
+    ).toBe('vulnerability-engine-manager-service');
+  });
+
+  it('returns service only when deployment is omitted', () => {
+    expect(buildInternalRouteKey(ServiceNames.compliance)).toBe('compliance');
+  });
+});
+
+describe('rewriteInternalProxiedPath', () => {
+  it('strips prefix with trailing path', () => {
+    expect(
+      rewriteInternalProxiedPath(
+        'vulnerability-engine-manager-service',
+        '/internal/vulnerability-engine-manager-service/api/vulnerability/v1/cves',
+      ),
+    ).toBe('/api/vulnerability/v1/cves');
+  });
+
+  it('returns empty string for exact prefix match', () => {
+    expect(
+      rewriteInternalProxiedPath('compliance', '/internal/compliance'),
+    ).toBe('');
+  });
+
+  it('returns path unchanged when prefix does not match', () => {
+    expect(rewriteInternalProxiedPath('compliance', '/api/foo')).toBe(
+      '/api/foo',
+    );
+  });
+});

--- a/src/common/integrationEndpoints.ts
+++ b/src/common/integrationEndpoints.ts
@@ -1,0 +1,95 @@
+import { Endpoint } from 'app-common-js';
+import {
+  ServiceNames,
+  IntegrationEndpointsMap,
+} from '../integration/endpoints';
+
+function isIntegratedApp(app: string): app is ServiceNames {
+  return Object.values(ServiceNames).includes(app as ServiceNames);
+}
+
+function isIntegratedEndpoint(
+  endpoint: Endpoint,
+): endpoint is Endpoint & { app: ServiceNames } {
+  return isIntegratedApp(endpoint.app);
+}
+
+export type IntegrationRouteKey = ServiceNames | `${ServiceNames}-${string}`;
+
+export function buildInternalRouteKey(
+  service: ServiceNames,
+  clowderDeploymentName?: string,
+): IntegrationRouteKey {
+  return clowderDeploymentName
+    ? `${service}-${clowderDeploymentName}`
+    : service;
+}
+
+export function mergeClowderEndpoints(
+  privateEndpoints: Endpoint[] | undefined,
+  publicEndpoints: Endpoint[],
+): IntegrationEndpointsMap {
+  const merged: Endpoint[] = [...(privateEndpoints ?? []), ...publicEndpoints];
+  const seen = new Set<string>();
+  const integrated = merged.filter(
+    (ep): ep is Endpoint & { app: ServiceNames } => {
+      if (!isIntegratedEndpoint(ep)) {
+        return false;
+      }
+      const id = `${ep.app}/${ep.name}`;
+      if (seen.has(id)) {
+        return false;
+      }
+      seen.add(id);
+      return true;
+    },
+  );
+  const appCount = integrated.reduce<Record<string, number>>(
+    (acc, endpoint) => {
+      acc[endpoint.app] = (acc[endpoint.app] ?? 0) + 1;
+      return acc;
+    },
+    {},
+  );
+  const out: IntegrationEndpointsMap = {};
+  for (const endpoint of integrated) {
+    const key = buildInternalRouteKey(
+      endpoint.app,
+      (appCount[endpoint.app] ?? 0) > 1 ? endpoint.name : undefined,
+    );
+    out[key] = {
+      app: endpoint.app,
+      hostname: endpoint.hostname,
+      name: endpoint.name,
+      port: endpoint.port,
+    };
+  }
+  return out;
+}
+
+export function resolveInternalRouteKey(
+  service: ServiceNames,
+  endpoints: IntegrationEndpointsMap,
+  clowderDeploymentName?: string,
+): IntegrationRouteKey | undefined {
+  const candidates: IntegrationRouteKey[] = [];
+  if (clowderDeploymentName) {
+    candidates.push(buildInternalRouteKey(service, clowderDeploymentName));
+  }
+  candidates.push(service);
+  return candidates.find((key) => endpoints[key] !== undefined);
+}
+
+export function rewriteInternalProxiedPath(
+  routeKey: string,
+  path: string,
+): string {
+  const prefix = `/internal/${routeKey}`;
+  if (path.startsWith(`${prefix}/`)) {
+    return path.slice(prefix.length);
+  }
+  if (path === prefix) {
+    return '';
+  }
+  return path;
+}

--- a/src/integration/endpoints.ts
+++ b/src/integration/endpoints.ts
@@ -12,3 +12,7 @@ export enum ServiceNames {
 export type ServicesEndpoints = {
   [key in ServiceNames]: Endpoint;
 };
+
+export type IntegrationEndpointsMap = Partial<
+  Record<ServiceNames | `${ServiceNames}-${string}`, Endpoint>
+>;

--- a/src/server/routes/createInternalProxies.ts
+++ b/src/server/routes/createInternalProxies.ts
@@ -1,9 +1,9 @@
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import instanceConfig from '../../common/config';
-import { ServiceNames } from '../../integration/endpoints';
 import { Endpoint } from 'app-common-js';
 import { hpmLogger } from '../../common/logging';
 import { HttpsProxyAgent } from 'https-proxy-agent';
+import { rewriteInternalProxiedPath } from '../../common/integrationEndpoints';
 
 const API_HOST = instanceConfig.scalprum.apiHost;
 const PROXY_AGENT = instanceConfig.scalprum.proxyAgent;
@@ -17,38 +17,24 @@ function createInternalProxies() {
       logger: hpmLogger,
       target: API_HOST,
       changeOrigin: true,
-      pathFilter: (path) => path.startsWith('/internal'),
+      pathFilter: (path) => path.startsWith('/internal/'),
       pathRewrite: (path) => path.replace(internalRegEx, ''),
     });
     return [proxy];
   }
-  const meta = Object.entries(instanceConfig.endpoints).reduce<
-    Partial<{
-      [key in ServiceNames]: Endpoint;
-    }>
-  >((acc, [serviceName, endpoint]) => {
-    const index: ServiceNames = ServiceNames[serviceName as ServiceNames];
-    if (ServiceNames[index]) {
-      acc[ServiceNames[index]] = endpoint;
-    }
-    return acc;
-  }, {});
 
-  const internalProxies = Object.entries(meta).map(
-    ([serviceName, endpoint]) => {
+  return Object.entries(instanceConfig.endpoints)
+    .filter((pair): pair is [string, Endpoint] => pair[1] !== undefined)
+    .map(([routeKey, endpoint]) => {
+      const prefix = `/internal/${routeKey}`;
       return createProxyMiddleware({
         logger: hpmLogger,
         target: `http://${endpoint.hostname}:${endpoint.port}`,
         changeOrigin: true,
-        pathFilter: (path) => path.startsWith(`/internal/${serviceName}`),
-        pathRewrite: {
-          [`^/internal/${serviceName}`]: '',
-        },
+        pathFilter: (path) => path.startsWith(`${prefix}/`) || path === prefix,
+        pathRewrite: (path) => rewriteInternalProxiedPath(routeKey, path),
       });
-    },
-  );
-
-  return internalProxies;
+    });
 }
 
 export default createInternalProxies;


### PR DESCRIPTION
### Description
I'm trying to debug pdf-generator for vulnerability-ui in stage. Currently it half works but API reaches incorrect service [manager-admin-service](https://github.com/RedHatInsights/vulnerability-engine/blob/master/deploy/clowdapp.yaml#L126) which has no implemented endpoint and as the result we get 404. It should use [manager-service](https://github.com/RedHatInsights/vulnerability-engine/blob/master/deploy/clowdapp.yaml#L15C13-L15C20) instead. I think it happens because they might share the same app name and the last one (manager-admin-service) overrides the first one [here](https://github.com/RedHatInsights/pdf-generator/blob/main/src/common/config.ts#L167-L174).

Based on ACG file vulnerability-engine has two entries
"vulnerability-engine":{
"manager-admin-service":{"uri":"[http://vulnerability-engine-manager-admin-service.ephemeral-hfwnhp.svc:8000/"}](http://vulnerability-engine-manager-admin-service.ephemeral-hfwnhp.svc:8000/%22%7D),
"manager-service":{"uri":"[http://vulnerability-engine-manager-service.ephemeral-hfwnhp.svc:8000/"}}}](http://vulnerability-engine-manager-service.ephemeral-hfwnhp.svc:8000/%22%7D%7D%7D)
}
so with the current config - it just picks one of these instead of using correct one. Because of that, pdf generator fails to generate PDF

with the new approach - apps will be able to pass `clowderDeploymentName` for pdf-generator that will detect what endpoints to use.
```
  const { data: cves, meta } = await createAsyncRequest(
    'vulnerability-engine',
    {
      method: 'GET',
      url: `/api/vulnerability/v1/vulnerabilities/cves`,
      params: {
        ...allParams,
        report: 'true',
        advanced_report: 'true',
      },
      clowderDeploymentName: VULNERABILITY_ENGINE_CVE_DEPLOYMENT,
    },
  );
  ```

---

### How to test locally
<!-- How can a reviewer exercise this? Special setup, env vars, seed data? -->
<!-- Bug fixes: how to reproduce the original bug and confirm the fix. -->

---

### Anything reviewers should know?
<!-- Trade-offs, performance considerations, pre/post merge actions required. -->

---

### Checklist
- [ ] Tests: new/updated tests cover the change
- [ ] API: spec updated if endpoints changed (or N/A)
- [ ] Migrations: backwards compatible if schema changed (or N/A)
- [ ] Dependencies: no known impact to dependent services
- [ ] Security: reviewed against [secure coding checklist](https://github.com/RedHatInsights/secure-coding-checklist) (or N/A)

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
