### PR TITLE
fix: resolve auth forwarding, error handling, and token refresh for large PDFs

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -62,6 +62,10 @@ objects:
           value: ${ASSETS_HOST}
         - name: PROXY_AGENT
           value: ${PROXY_AGENT}
+        - name: SSO_URL
+          value: ${SSO_URL}
+        - name: SSO_CLIENT_ID
+          value: ${SSO_CLIENT_ID}
         resources:
           limits:
             cpu: ${CPU_LIMIT_SERVICE}
@@ -118,3 +122,9 @@ parameters:
 - description: Amount of worker threads that puppeteer-cluster will use
   name: MAX_CONCURRENCY
   value: "2"
+- description: SSO/Keycloak base URL for token refresh
+  name: SSO_URL
+  value: ""
+- description: SSO client ID for token refresh
+  name: SSO_CLIENT_ID
+  value: "cloud-services"

--- a/src/browser/clusterTask.spec.ts
+++ b/src/browser/clusterTask.spec.ts
@@ -1,0 +1,386 @@
+import PdfCache, { PdfStatus } from '../common/pdfCache';
+import { generatePdf } from './clusterTask';
+import { AuthState, PdfRequestBody } from '../common/types';
+
+const mockPage = {
+  setViewport: jest.fn(),
+  on: jest.fn(),
+  evaluate: jest.fn().mockResolvedValue(undefined),
+  goto: jest
+    .fn()
+    .mockResolvedValue({ status: () => 200, statusText: () => 'OK' }),
+  waitForNetworkIdle: jest.fn(),
+  setExtraHTTPHeaders: jest.fn(),
+  setRequestInterception: jest.fn(),
+  setCookie: jest.fn(),
+  pdf: jest.fn().mockResolvedValue(Buffer.from('')),
+  close: jest.fn(),
+};
+
+jest.mock('../server/cluster', () => ({
+  cluster: {
+    queue: jest.fn((taskFn: ({ page }: { page: unknown }) => Promise<void>) =>
+      taskFn({ page: mockPage }),
+    ),
+  },
+}));
+
+jest.mock('../common/config', () => ({
+  __esModule: true,
+  default: {
+    webPort: 8000,
+    OPTIONS_HEADER_NAME: 'x-pdf-gen-options',
+    IDENTITY_HEADER_KEY: 'x-rh-identity',
+    AUTHORIZATION_CONTEXT_KEY: 'x-pdf-auth',
+    AUTHORIZATION_HEADER_KEY: 'Authorization',
+    JWT_COOKIE_NAME: 'cs_jwt',
+    SSO_URL: 'https://sso.example.com/auth/',
+    SSO_CLIENT_ID: 'cloud-services',
+  },
+}));
+
+jest.mock('../common/logging', () => ({
+  apiLogger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    warning: jest.fn(),
+  },
+}));
+
+jest.mock('../server/utils', () => ({
+  UpdateStatus: jest.fn(),
+  isValidPageResponse: (code: number) => code >= 200 && code < 400,
+}));
+
+jest.mock('./helpers', () => ({
+  pageWidth: 1024,
+  pageHeight: 768,
+  setWindowProperty: jest.fn(),
+}));
+
+jest.mock('../server/render-template', () => ({
+  getHeaderAndFooterTemplates: () => ({
+    headerTemplate: '<div></div>',
+    footerTemplate: '<div></div>',
+  }),
+}));
+
+jest.mock('../common/store', () => ({
+  store: {
+    uploadPDF: jest.fn().mockResolvedValue(undefined),
+  },
+}));
+
+jest.mock('pdf-lib', () => ({
+  PDFDocument: {
+    load: jest.fn().mockResolvedValue({
+      getPages: () => [{}],
+    }),
+  },
+}));
+
+jest.mock('./tokenRefresh', () => ({
+  isTokenExpiringSoon: jest.fn().mockReturnValue(false),
+  refreshAccessToken: jest.fn(),
+}));
+
+const { UpdateStatus } = jest.requireMock('../server/utils');
+const { isTokenExpiringSoon, refreshAccessToken } =
+  jest.requireMock('./tokenRefresh');
+
+function makePdfRequest(
+  overrides: Partial<PdfRequestBody> = {},
+): PdfRequestBody {
+  return {
+    manifestLocation: 'https://example.com/manifest.json',
+    scope: 'test',
+    module: './TestModule',
+    uuid: 'comp-' + Math.random().toString(36).slice(2, 8),
+    url: 'http://localhost:8000/puppeteer?scope=test',
+    ...overrides,
+  };
+}
+
+function makeAuthState(overrides: Partial<AuthState> = {}): AuthState {
+  return {
+    authHeader: 'Bearer some-token',
+    refreshToken: 'Bearer some-refresh-token',
+    ...overrides,
+  };
+}
+
+function initCollection(collectionId: string) {
+  const pdfCache = PdfCache.getInstance();
+  pdfCache.setExpectedLength(collectionId, 1);
+}
+
+describe('generatePdf', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPage.goto.mockResolvedValue({
+      status: () => 200,
+      statusText: () => 'OK',
+    });
+    mockPage.evaluate.mockResolvedValue(undefined);
+    mockPage.pdf.mockResolvedValue(Buffer.from(''));
+    mockPage.close.mockResolvedValue(undefined);
+  });
+
+  describe('successful generation', () => {
+    it('updates status to Generating then Generated', async () => {
+      const req = makePdfRequest();
+      await generatePdf(req, 'coll-1', 1, makeAuthState());
+
+      expect(UpdateStatus).toHaveBeenCalledTimes(2);
+      expect(UpdateStatus).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          status: PdfStatus.Generating,
+          componentId: req.uuid,
+          collectionId: 'coll-1',
+        }),
+      );
+      expect(UpdateStatus).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          status: PdfStatus.Generated,
+          componentId: req.uuid,
+          collectionId: 'coll-1',
+        }),
+      );
+    });
+
+    it('closes the page after success', async () => {
+      await generatePdf(makePdfRequest(), 'coll-1', 1, makeAuthState());
+      expect(mockPage.close).toHaveBeenCalled();
+    });
+
+    it('sets auth header from authState', async () => {
+      const authState = makeAuthState({ authHeader: 'Bearer my-token' });
+      await generatePdf(makePdfRequest(), 'coll-1', 1, authState);
+
+      expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'x-pdf-auth': 'Bearer my-token',
+        }),
+      );
+    });
+  });
+
+  describe('page render error', () => {
+    it('updates status to Failed when DOM error element exists', async () => {
+      mockPage.evaluate.mockResolvedValue(
+        'Request failed with status code 401',
+      );
+      const req = makePdfRequest();
+      initCollection('coll-err');
+
+      await generatePdf(req, 'coll-err', 1, makeAuthState());
+
+      expect(UpdateStatus).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          status: PdfStatus.Failed,
+          componentId: req.uuid,
+          collectionId: 'coll-err',
+          error: expect.stringContaining('Page render error'),
+        }),
+      );
+    });
+
+    it('invalidates the collection on render error', async () => {
+      mockPage.evaluate.mockResolvedValue('Some error');
+      initCollection('coll-inv');
+      const pdfCache = PdfCache.getInstance();
+      const spy = jest.spyOn(pdfCache, 'invalidateCollection');
+
+      await generatePdf(makePdfRequest(), 'coll-inv', 1, makeAuthState());
+
+      expect(spy).toHaveBeenCalledWith('coll-inv', expect.any(String));
+      spy.mockRestore();
+    });
+
+    it('closes the page after render error', async () => {
+      mockPage.evaluate.mockResolvedValue('Error');
+      initCollection('coll-close-err');
+      await generatePdf(makePdfRequest(), 'coll-close-err', 1, makeAuthState());
+      expect(mockPage.close).toHaveBeenCalled();
+    });
+  });
+
+  describe('page load failure', () => {
+    it('updates status to Failed on 500 response', async () => {
+      mockPage.goto.mockResolvedValue({
+        status: () => 500,
+        statusText: () => 'Internal Server Error',
+      });
+      const req = makePdfRequest();
+      initCollection('coll-500');
+
+      await generatePdf(req, 'coll-500', 1, makeAuthState());
+
+      expect(UpdateStatus).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          status: PdfStatus.Failed,
+          componentId: req.uuid,
+          error: expect.stringContaining('Puppeteer error'),
+        }),
+      );
+    });
+
+    it('updates status to Failed on null response', async () => {
+      mockPage.goto.mockResolvedValue(null);
+      const req = makePdfRequest();
+      initCollection('coll-null');
+
+      await generatePdf(req, 'coll-null', 1, makeAuthState());
+
+      expect(UpdateStatus).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          status: PdfStatus.Failed,
+        }),
+      );
+    });
+  });
+
+  describe('timeout failure', () => {
+    it('updates status to Failed on page.goto timeout', async () => {
+      mockPage.goto.mockRejectedValue(
+        new Error('TimeoutError: Navigation timeout of 120000ms exceeded'),
+      );
+      const req = makePdfRequest();
+      initCollection('coll-timeout');
+
+      await generatePdf(req, 'coll-timeout', 1, makeAuthState());
+
+      expect(UpdateStatus).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          status: PdfStatus.Failed,
+          error: expect.stringContaining('timeout'),
+        }),
+      );
+    });
+  });
+
+  describe('collection already failed', () => {
+    it('skips generation and marks component as Failed', async () => {
+      const pdfCache = PdfCache.getInstance();
+      jest.spyOn(pdfCache, 'isCollectionFailed').mockReturnValue(true);
+      const req = makePdfRequest();
+
+      await generatePdf(req, 'coll-already-failed', 1, makeAuthState());
+
+      expect(UpdateStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: PdfStatus.Failed,
+          componentId: req.uuid,
+          error: 'Collection failed before this component started',
+        }),
+      );
+      expect(mockPage.goto).not.toHaveBeenCalled();
+
+      jest.restoreAllMocks();
+    });
+  });
+
+  describe('token refresh integration', () => {
+    it('refreshes token before setting headers when expiring', async () => {
+      isTokenExpiringSoon.mockReturnValue(true);
+      refreshAccessToken.mockResolvedValue({
+        accessToken: 'Bearer refreshed-token',
+      });
+      const authState = makeAuthState();
+
+      await generatePdf(makePdfRequest(), 'coll-refresh', 1, authState);
+
+      expect(refreshAccessToken).toHaveBeenCalledWith(
+        'Bearer some-refresh-token',
+      );
+      expect(authState.authHeader).toBe('Bearer refreshed-token');
+      expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'x-pdf-auth': 'Bearer refreshed-token',
+        }),
+      );
+    });
+
+    it('keeps original token when refresh fails', async () => {
+      isTokenExpiringSoon.mockReturnValue(true);
+      refreshAccessToken.mockResolvedValue(null);
+      const authState = makeAuthState({ authHeader: 'Bearer original' });
+
+      await generatePdf(makePdfRequest(), 'coll-no-refresh', 1, authState);
+
+      expect(authState.authHeader).toBe('Bearer original');
+      expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'x-pdf-auth': 'Bearer original',
+        }),
+      );
+    });
+
+    it('does not refresh when token is still fresh', async () => {
+      isTokenExpiringSoon.mockReturnValue(false);
+
+      await generatePdf(makePdfRequest(), 'coll-fresh', 1, makeAuthState());
+
+      expect(refreshAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('does not refresh when no refresh token is available', async () => {
+      isTokenExpiringSoon.mockReturnValue(true);
+      const authState = makeAuthState({ refreshToken: undefined });
+
+      await generatePdf(makePdfRequest(), 'coll-no-rt', 1, authState);
+
+      expect(refreshAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('generates successfully without refresh token', async () => {
+      isTokenExpiringSoon.mockReturnValue(false);
+      const authState = makeAuthState({ refreshToken: undefined });
+
+      await generatePdf(makePdfRequest(), 'coll-no-rt-ok', 1, authState);
+
+      expect(refreshAccessToken).not.toHaveBeenCalled();
+      expect(UpdateStatus).toHaveBeenLastCalledWith(
+        expect.objectContaining({ status: PdfStatus.Generated }),
+      );
+    });
+
+    it('generates successfully without any auth', async () => {
+      isTokenExpiringSoon.mockReturnValue(false);
+      const authState: AuthState = {};
+
+      await generatePdf(makePdfRequest(), 'coll-no-auth', 1, authState);
+
+      expect(refreshAccessToken).not.toHaveBeenCalled();
+      expect(UpdateStatus).toHaveBeenLastCalledWith(
+        expect.objectContaining({ status: PdfStatus.Generated }),
+      );
+      expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
+        expect.not.objectContaining({ 'x-pdf-auth': expect.anything() }),
+      );
+    });
+
+    it('updates shared authState so subsequent tasks see refreshed token', async () => {
+      const authState = makeAuthState();
+      isTokenExpiringSoon.mockReturnValueOnce(true).mockReturnValue(false);
+      refreshAccessToken.mockResolvedValue({
+        accessToken: 'Bearer new-shared-token',
+      });
+
+      await generatePdf(makePdfRequest(), 'coll-shared-1', 1, authState);
+
+      expect(authState.authHeader).toBe('Bearer new-shared-token');
+
+      await generatePdf(makePdfRequest(), 'coll-shared-2', 2, authState);
+
+      expect(mockPage.setExtraHTTPHeaders).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          'x-pdf-auth': 'Bearer new-shared-token',
+        }),
+      );
+    });
+  });
+});

--- a/src/browser/clusterTask.ts
+++ b/src/browser/clusterTask.ts
@@ -164,7 +164,10 @@ async function runPageTask(
             assetCache.set(assetCacheKey(respUrl), {
               body,
               contentType:
-                resp.headers()['content-type'] || 'application/javascript',
+                resp.headers()['content-type'] ||
+                (respUrl.match(/\.css(\?|$)/)
+                  ? 'text/css'
+                  : 'application/javascript'),
             });
           } catch {
             // response body may not be available

--- a/src/browser/clusterTask.ts
+++ b/src/browser/clusterTask.ts
@@ -1,5 +1,5 @@
 import os from 'os';
-import { PdfRequestBody } from '../common/types';
+import { AuthState, PdfRequestBody } from '../common/types';
 import { apiLogger } from '../common/logging';
 import { pageHeight, pageWidth, setWindowProperty } from './helpers';
 import PdfCache, { PdfStatus } from '../common/pdfCache';
@@ -11,53 +11,76 @@ import { PdfGenerationError } from '../server/errors';
 import { cluster } from '../server/cluster';
 import { Page } from 'puppeteer';
 import { PDFDocument } from 'pdf-lib';
+import { isTokenExpiringSoon, refreshAccessToken } from './tokenRefresh';
 
-// Match the timeout on the gateway
-const BROWSER_TIMEOUT = 60_000;
+const BROWSER_TIMEOUT = 120_000;
+
+const assetCache = new Map<string, { body: Buffer; contentType: string }>();
+
+function assetCacheKey(url: string): string {
+  return url.split('?')[0];
+}
 
 const getNewPdfName = (id: string) => {
   const pdfFilename = `report_${id}.pdf`;
   return `${os.tmpdir()}/${pdfFilename}`;
 };
 
-export const generatePdf = async (
+async function runPageTask(
   {
     url,
     identity,
     fetchDataParams,
     landscape = false,
     uuid: componentId,
-    authHeader,
-    authCookie,
   }: PdfRequestBody,
   collectionId: string,
   order: number,
-): Promise<void> => {
-  const pdfPath = getNewPdfName(componentId);
-  try {
-    await cluster.queue(async ({ page }: { page: Page }) => {
-      // If another component in this collection already failed,
-      // skip all expensive work (page navigation, API requests, PDF generation)
-      if (PdfCache.getInstance().isCollectionFailed(collectionId)) {
-        apiLogger.debug(
-          `Skipping component ${componentId}: collection ${collectionId} already failed`,
-        );
-        return;
-      }
+  pdfPath: string,
+  authState: AuthState,
+): Promise<void> {
+  await cluster.queue(async ({ page }: { page: Page }) => {
+    if (PdfCache.getInstance().isCollectionFailed(collectionId)) {
+      apiLogger.debug(
+        `Skipping component ${componentId}: collection ${collectionId} already failed`,
+      );
+      await UpdateStatus({
+        collectionId,
+        status: PdfStatus.Failed,
+        filepath: '',
+        componentId,
+        order,
+        error: 'Collection failed before this component started',
+      });
+      return;
+    }
 
-      const updateMessage = {
+    try {
+      await UpdateStatus({
         status: PdfStatus.Generating,
         filepath: '',
-        order: order,
-        componentId: componentId,
+        order,
+        componentId,
         collectionId,
-      };
-      await UpdateStatus(updateMessage);
+      });
       await page.setViewport({ width: pageWidth, height: pageHeight });
-      // Enables console logging in Headless mode - handy for debugging components
       page.on('console', (msg) =>
         apiLogger.info(`[Headless log] ${msg.text()}`),
       );
+
+      page.on('response', async (response) => {
+        if (response.status() >= 400) {
+          let body = '';
+          try {
+            body = await response.text();
+          } catch {
+            body = '<unreadable>';
+          }
+          apiLogger.debug(
+            `[Headless response] ${response.status()} ${response.url()} | body=${body}`,
+          );
+        }
+      });
 
       await setWindowProperty(
         page,
@@ -70,6 +93,21 @@ export const generatePdf = async (
         }),
       );
 
+      // Refresh token if expiring before setting headers
+      if (
+        authState.refreshToken &&
+        authState.authHeader &&
+        isTokenExpiringSoon(authState.authHeader.replace(/^Bearer\s+/i, ''))
+      ) {
+        apiLogger.debug(
+          `[token-refresh] Refreshing before component ${componentId}`,
+        );
+        const refreshed = await refreshAccessToken(authState.refreshToken);
+        if (refreshed) {
+          authState.authHeader = refreshed.accessToken;
+        }
+      }
+
       const extraHeaders: Record<string, string> = {};
       if (identity) {
         extraHeaders['x-rh-identity'] = identity;
@@ -80,18 +118,59 @@ export const generatePdf = async (
           JSON.stringify(fetchDataParams);
       }
 
-      if (authHeader) {
-        extraHeaders[config.AUTHORIZATION_CONTEXT_KEY] = authHeader;
+      if (authState.authHeader) {
+        extraHeaders[config.AUTHORIZATION_CONTEXT_KEY] = authState.authHeader;
       }
 
-      if (authCookie) {
+      if (authState.authCookie) {
         await page.setCookie({
           name: config.JWT_COOKIE_NAME,
-          value: authCookie,
-          // We might have to change the domain to match the proxy
+          value: authState.authCookie,
           domain: 'localhost',
         });
       }
+
+      await page.setRequestInterception(true);
+      page.on('request', async (interceptedRequest) => {
+        const reqUrl = interceptedRequest.url();
+        if (
+          interceptedRequest.method() === 'GET' &&
+          reqUrl.includes('/apps/') &&
+          /\.(js|css)(\?|$)/.test(reqUrl)
+        ) {
+          const cached = assetCache.get(assetCacheKey(reqUrl));
+          if (cached) {
+            await interceptedRequest.respond({
+              status: 200,
+              contentType: cached.contentType,
+              body: cached.body,
+            });
+            return;
+          }
+        }
+        await interceptedRequest.continue();
+      });
+
+      page.on('response', async (resp) => {
+        const respUrl = resp.url();
+        if (
+          resp.ok() &&
+          respUrl.includes('/apps/') &&
+          /\.(js|css)(\?|$)/.test(respUrl) &&
+          !assetCache.has(assetCacheKey(respUrl))
+        ) {
+          try {
+            const body = await resp.buffer();
+            assetCache.set(assetCacheKey(respUrl), {
+              body,
+              contentType:
+                resp.headers()['content-type'] || 'application/javascript',
+            });
+          } catch {
+            // response body may not be available
+          }
+        }
+      });
 
       await page.setExtraHTTPHeaders(extraHeaders);
 
@@ -99,16 +178,11 @@ export const generatePdf = async (
         waitUntil: 'networkidle2',
         timeout: BROWSER_TIMEOUT,
       });
-      // wait for subsequent network requests to finish
       await page.waitForNetworkIdle({
         idleTime: 1000,
       });
-      // because a cached response is a 3xx, puppeteer counts cache as an error
-      // so we don't use pageResponse.ok()
       const pageStatus = pageResponse?.status();
 
-      // get the error from DOM if it exists
-      // check both the app-level error element and the template rendering error
       const error = await page.evaluate(() => {
         const appError = document.getElementById('crc-pdf-generator-err');
         if (appError) {
@@ -120,29 +194,16 @@ export const generatePdf = async (
         }
       });
 
-      // error happened during page rendering
       if (error && error.length > 0) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let response: any;
         try {
-          // error should be JSON
           response = JSON.parse(error);
           apiLogger.debug(response.data);
         } catch {
-          // fallback to initial error value
           response = error;
           apiLogger.debug(`Page render error ${response}`);
         }
-        const updated = {
-          collectionId,
-          status: PdfStatus.Failed,
-          filepath: '',
-          componentId: componentId,
-          error: response,
-          order: order,
-        };
-        await UpdateStatus(updated);
-        PdfCache.getInstance().invalidateCollection(collectionId, response);
         throw new PdfGenerationError(
           collectionId,
           componentId,
@@ -151,19 +212,6 @@ export const generatePdf = async (
       }
       if (!pageStatus || !isValidPageResponse(pageStatus)) {
         apiLogger.debug(`Page status: ${pageResponse?.statusText()}`);
-        const updated = {
-          collectionId,
-          status: PdfStatus.Failed,
-          filepath: '',
-          componentId: componentId,
-          order: order,
-          error: pageResponse?.statusText() || 'Page status not found',
-        };
-        await UpdateStatus(updated);
-        PdfCache.getInstance().invalidateCollection(
-          collectionId,
-          pageResponse?.statusText() || 'Page status not found',
-        );
         throw new PdfGenerationError(
           collectionId,
           componentId,
@@ -171,8 +219,6 @@ export const generatePdf = async (
         );
       }
 
-      // Re-check after page load in case another component failed while
-      // this one was waiting for network requests to complete
       if (PdfCache.getInstance().isCollectionFailed(collectionId)) {
         apiLogger.debug(
           `Aborting component ${componentId}: collection ${collectionId} failed during page load`,
@@ -182,78 +228,59 @@ export const generatePdf = async (
 
       const { headerTemplate, footerTemplate } = getHeaderAndFooterTemplates();
 
-      try {
-        const buffer = await page.pdf({
-          path: pdfPath,
-          format: 'a4',
-          printBackground: true,
-          margin: {
-            top: '54px',
-            bottom: '54px',
-          },
-          landscape,
-          displayHeaderFooter: true,
-          headerTemplate,
-          footerTemplate,
-          timeout: BROWSER_TIMEOUT,
-        });
-        await store.uploadPDF(componentId, pdfPath).catch((error: unknown) => {
-          apiLogger.error(`Failed to upload PDF: ${error}`);
-        });
-        const pdfDoc = await PDFDocument.load(buffer);
-        const numPages = pdfDoc.getPages().length;
-        apiLogger.debug(`Generated PDF with ${numPages} pages`);
-        const updated = {
-          collectionId,
-          status: PdfStatus.Generated,
-          filepath: pdfPath,
-          componentId: componentId,
-          numPages: numPages,
-          order: order,
-        };
-        await UpdateStatus(updated);
-      } catch (error: unknown) {
-        const updated = {
-          collectionId,
-          status: PdfStatus.Failed,
-          filepath: '',
-          componentId: componentId,
-          order: order,
-          error: JSON.stringify(error),
-        };
-        await UpdateStatus(updated);
-        PdfCache.getInstance().invalidateCollection(
-          collectionId,
-          JSON.stringify(error),
-        );
-        throw new PdfGenerationError(
-          collectionId,
-          componentId,
-          `Failed to print pdf: ${JSON.stringify(error)}`,
-        );
-      } finally {
-        await page.close();
-      }
-    });
-  } catch (error: unknown) {
-    // Catch any errors that escape the cluster queue (e.g., cluster shutdown, browser crash)
-    // This prevents unhandled rejections when generatePdf is called without await
-    apiLogger.error(
-      `generatePdf outer catch for ${componentId}:`,
-      JSON.stringify(error),
-    );
-    const updated = {
-      collectionId,
-      status: PdfStatus.Failed,
-      filepath: '',
-      componentId: componentId,
-      order: order,
-      error: JSON.stringify(error),
-    };
-    await UpdateStatus(updated);
-    PdfCache.getInstance().invalidateCollection(
-      collectionId,
-      JSON.stringify(error),
-    );
-  }
+      const buffer = await page.pdf({
+        path: pdfPath,
+        format: 'a4',
+        printBackground: true,
+        margin: {
+          top: '54px',
+          bottom: '54px',
+        },
+        landscape,
+        displayHeaderFooter: true,
+        headerTemplate,
+        footerTemplate,
+        timeout: BROWSER_TIMEOUT,
+      });
+      await store.uploadPDF(componentId, pdfPath).catch((error: unknown) => {
+        apiLogger.error(`Failed to upload PDF: ${error}`);
+      });
+      const pdfDoc = await PDFDocument.load(buffer);
+      const numPages = pdfDoc.getPages().length;
+      apiLogger.debug(`Generated PDF with ${numPages} pages`);
+      await UpdateStatus({
+        collectionId,
+        status: PdfStatus.Generated,
+        filepath: pdfPath,
+        componentId,
+        numPages,
+        order,
+      });
+    } catch (taskError: unknown) {
+      const message =
+        taskError instanceof Error ? taskError.message : String(taskError);
+      apiLogger.error(`Component ${componentId} failed: ${message}`);
+      await UpdateStatus({
+        collectionId,
+        status: PdfStatus.Failed,
+        filepath: '',
+        componentId,
+        order,
+        error: message,
+      });
+      PdfCache.getInstance().invalidateCollection(collectionId, message);
+    } finally {
+      await page.close().catch(() => {});
+    }
+  });
+}
+
+export const generatePdf = async (
+  pdfRequest: PdfRequestBody,
+  collectionId: string,
+  order: number,
+  authState: AuthState,
+): Promise<void> => {
+  const pdfPath = getNewPdfName(pdfRequest.uuid);
+  await runPageTask(pdfRequest, collectionId, order, pdfPath, authState);
 };

--- a/src/browser/tokenRefresh.spec.ts
+++ b/src/browser/tokenRefresh.spec.ts
@@ -1,0 +1,141 @@
+import { isTokenExpiringSoon, refreshAccessToken } from './tokenRefresh';
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256' })).toString(
+    'base64url',
+  );
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.fake-signature`;
+}
+
+jest.mock('../common/config', () => ({
+  __esModule: true,
+  default: {
+    SSO_URL: 'https://sso.example.com/auth/',
+    SSO_CLIENT_ID: 'cloud-services',
+  },
+}));
+
+jest.mock('../common/logging', () => ({
+  apiLogger: {
+    debug: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+describe('isTokenExpiringSoon', () => {
+  it('returns true when token expires within 60 seconds', () => {
+    const exp = Math.floor(Date.now() / 1000) + 30;
+    expect(isTokenExpiringSoon(makeJwt({ exp }))).toBe(true);
+  });
+
+  it('returns true when token is already expired', () => {
+    const exp = Math.floor(Date.now() / 1000) - 100;
+    expect(isTokenExpiringSoon(makeJwt({ exp }))).toBe(true);
+  });
+
+  it('returns false when token has plenty of time left', () => {
+    const exp = Math.floor(Date.now() / 1000) + 600;
+    expect(isTokenExpiringSoon(makeJwt({ exp }))).toBe(false);
+  });
+
+  it('returns false for malformed token', () => {
+    expect(isTokenExpiringSoon('not-a-jwt')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(isTokenExpiringSoon('')).toBe(false);
+  });
+
+  it('returns false when payload has no exp claim', () => {
+    expect(isTokenExpiringSoon(makeJwt({ sub: 'user' }))).toBe(false);
+  });
+});
+
+describe('refreshAccessToken', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('returns new access token on successful refresh', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ access_token: 'new-token-123' }),
+    });
+
+    const result = await refreshAccessToken('old-refresh-token');
+
+    expect(result).toEqual({ accessToken: 'Bearer new-token-123' });
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://sso.example.com/auth/realms/redhat-external/protocol/openid-connect/token',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      }),
+    );
+  });
+
+  it('strips Bearer prefix from refresh token', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ access_token: 'new-token' }),
+    });
+
+    await refreshAccessToken('Bearer my-refresh-token');
+
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    const body = call[1].body;
+    expect(body).toContain('refresh_token=my-refresh-token');
+    expect(body).not.toContain('Bearer');
+  });
+
+  it('sends correct client_id and grant_type', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ access_token: 'tok' }),
+    });
+
+    await refreshAccessToken('rt');
+
+    const call = (global.fetch as jest.Mock).mock.calls[0];
+    const body = call[1].body;
+    expect(body).toContain('grant_type=refresh_token');
+    expect(body).toContain('client_id=cloud-services');
+  });
+
+  it('returns null when SSO returns an error', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('invalid_grant'),
+    });
+
+    const result = await refreshAccessToken('bad-refresh-token');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on network failure', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await refreshAccessToken('some-token');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when SSO_URL is not configured', async () => {
+    const mockFetch = jest.fn();
+    global.fetch = mockFetch;
+
+    const configModule = jest.requireMock('../common/config');
+    const origUrl = configModule.default.SSO_URL;
+    configModule.default.SSO_URL = '';
+
+    const result = await refreshAccessToken('some-token');
+    expect(result).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    configModule.default.SSO_URL = origUrl;
+  });
+});

--- a/src/browser/tokenRefresh.ts
+++ b/src/browser/tokenRefresh.ts
@@ -1,0 +1,56 @@
+import config from '../common/config';
+import { apiLogger } from '../common/logging';
+
+const TOKEN_EXPIRY_BUFFER_MS = 60_000;
+
+export function isTokenExpiringSoon(token: string): boolean {
+  try {
+    const payload = JSON.parse(
+      Buffer.from(token.split('.')[1], 'base64').toString(),
+    );
+    const expiresAt = payload.exp * 1000;
+    return Date.now() + TOKEN_EXPIRY_BUFFER_MS > expiresAt;
+  } catch {
+    return false;
+  }
+}
+
+export async function refreshAccessToken(
+  refreshToken: string,
+): Promise<{ accessToken: string } | null> {
+  if (!config.SSO_URL) {
+    apiLogger.debug('[token-refresh] SSO_URL not configured, skipping refresh');
+    return null;
+  }
+
+  const tokenUrl = `${config.SSO_URL}realms/redhat-external/protocol/openid-connect/token`;
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    client_id: config.SSO_CLIENT_ID,
+    refresh_token: refreshToken.replace(/^Bearer\s+/i, ''),
+  });
+
+  try {
+    apiLogger.debug(`[token-refresh] Refreshing access token via ${tokenUrl}`);
+    const response = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      apiLogger.error(
+        `[token-refresh] Failed: ${response.status} ${text}`,
+      );
+      return null;
+    }
+
+    const data = (await response.json()) as { access_token: string };
+    apiLogger.debug('[token-refresh] Token refreshed successfully');
+    return { accessToken: `Bearer ${data.access_token}` };
+  } catch (error) {
+    apiLogger.error(`[token-refresh] Error: ${error}`);
+    return null;
+  }
+}

--- a/src/browser/tokenRefresh.ts
+++ b/src/browser/tokenRefresh.ts
@@ -40,9 +40,7 @@ export async function refreshAccessToken(
 
     if (!response.ok) {
       const text = await response.text();
-      apiLogger.error(
-        `[token-refresh] Failed: ${response.status} ${text}`,
-      );
+      apiLogger.error(`[token-refresh] Failed: ${response.status} ${text}`);
       return null;
     }
 

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -39,6 +39,10 @@ const defaultConfig: {
   JWT_COOKIE_NAME: string;
   AUTHORIZATION_HEADER_KEY: string;
   AUTHORIZATION_CONTEXT_KEY: string;
+  REFRESH_TOKEN_HEADER_KEY: string;
+  REFRESH_TOKEN_CONTEXT_KEY: string;
+  SSO_URL: string;
+  SSO_CLIENT_ID: string;
   ACCOUNT_ID: string;
   LOG_LEVEL: string;
   scalprum: {
@@ -106,6 +110,10 @@ const defaultConfig: {
   IDENTITY_HEADER_KEY: 'x-rh-identity',
   AUTHORIZATION_HEADER_KEY: 'Authorization',
   AUTHORIZATION_CONTEXT_KEY: 'x-pdf-auth',
+  REFRESH_TOKEN_HEADER_KEY: 'x-rh-refresh-token',
+  REFRESH_TOKEN_CONTEXT_KEY: 'x-pdf-refresh-token',
+  SSO_URL: process.env.SSO_URL || '',
+  SSO_CLIENT_ID: process.env.SSO_CLIENT_ID || 'cloud-services',
   JWT_COOKIE_NAME: 'cs_jwt',
   ACCOUNT_ID: '',
   LOG_LEVEL: process.env.LOG_LEVEL || 'debug',

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -47,9 +47,16 @@ export type PuppeteerBrowserRequest = Request<
   GeneratePayload
 >;
 
+export type AuthState = {
+  authHeader?: string;
+  refreshToken?: string;
+  authCookie?: string;
+};
+
 export type PdfRequestBody = GeneratePayload & {
   uuid: string;
   url: string;
+  refreshToken?: string;
 };
 
 export type CacheKey = {

--- a/src/middleware/identity-middleware.ts
+++ b/src/middleware/identity-middleware.ts
@@ -25,6 +25,12 @@ const identityMiddleware: Handler = (req, _res, next) => {
         req.header(config.AUTHORIZATION_HEADER_KEY),
       );
     }
+    if (req.header(config.REFRESH_TOKEN_HEADER_KEY)) {
+      httpContext.set(
+        config.REFRESH_TOKEN_CONTEXT_KEY,
+        req.header(config.REFRESH_TOKEN_HEADER_KEY),
+      );
+    }
     if (req.cookies[config.JWT_COOKIE_NAME]) {
       httpContext.set(
         config.JWT_COOKIE_NAME,

--- a/src/server/cluster.ts
+++ b/src/server/cluster.ts
@@ -1,7 +1,6 @@
 import { Cluster } from 'puppeteer-cluster';
 import config from '../common/config';
-// Match the timeout on the gateway
-const BROWSER_TIMEOUT = 60_000;
+const BROWSER_TIMEOUT = 120_000;
 import { CHROMIUM_PATH } from '../browser/helpers';
 import { apiLogger } from '../common/logging';
 
@@ -15,6 +14,7 @@ export const GetPupCluster = async () => {
     maxConcurrency: concurrency,
     // If a queued task fails, how many times will it retry before returning an error
     retryLimit: 2,
+    timeout: BROWSER_TIMEOUT,
     puppeteerOptions: {
       timeout: BROWSER_TIMEOUT,
       ...(config?.IS_PRODUCTION

--- a/src/server/routes/createInternalProxies.ts
+++ b/src/server/routes/createInternalProxies.ts
@@ -16,9 +16,24 @@ function createInternalProxies() {
       ...(PROXY_AGENT ? { agent: new HttpsProxyAgent(PROXY_AGENT) } : {}),
       logger: hpmLogger,
       target: API_HOST,
+      secure: false,
       changeOrigin: true,
       pathFilter: (path) => path.startsWith('/internal/'),
       pathRewrite: (path) => path.replace(internalRegEx, ''),
+      on: {
+        proxyReq: (proxyReq) => {
+          const authHeader = proxyReq.getHeader(
+            instanceConfig.AUTHORIZATION_CONTEXT_KEY,
+          );
+          if (authHeader) {
+            proxyReq.setHeader(
+              instanceConfig.AUTHORIZATION_HEADER_KEY,
+              authHeader,
+            );
+          }
+          proxyReq.removeHeader(instanceConfig.AUTHORIZATION_CONTEXT_KEY);
+        },
+      },
     });
     return [proxy];
   }

--- a/src/server/routes/routes.ts
+++ b/src/server/routes/routes.ts
@@ -9,6 +9,7 @@ import renderTemplate from '../render-template';
 import config from '../../common/config';
 import previewPdf from '../../browser/previewPDF';
 import {
+  AuthState,
   GenerateHandlerRequest,
   PdfRequestBody,
   PuppeteerBrowserRequest,
@@ -150,6 +151,7 @@ function getPdfRequestBody(payload: GeneratePayload): PdfRequestBody {
     authHeader:
       httpContext.get(config.AUTHORIZATION_CONTEXT_KEY) ||
       process.env.MOCK_TOKEN,
+    refreshToken: httpContext.get(config.REFRESH_TOKEN_CONTEXT_KEY),
     identity: httpContext.get(config?.IDENTITY_HEADER_KEY),
     uuid,
     url: requestURL.toString(),
@@ -208,18 +210,25 @@ router.post(
 
     try {
       const requiredCalls = requestConfigs.length;
+      const authState: AuthState = {
+        authHeader:
+          httpContext.get(config.AUTHORIZATION_CONTEXT_KEY) ||
+          process.env.MOCK_TOKEN,
+        refreshToken: httpContext.get(config.REFRESH_TOKEN_CONTEXT_KEY),
+        authCookie: httpContext.get(config.JWT_COOKIE_NAME),
+      };
       if (requiredCalls === 1) {
         const pdfDetails = getPdfRequestBody(requestConfigs[0]);
         apiLogger.debug(`Single call to generator queued for ${collectionId}`);
         pdfCache.setExpectedLength(collectionId, requiredCalls);
-        generatePdf(pdfDetails, collectionId, 1);
+        generatePdf(pdfDetails, collectionId, 1, authState);
         return res.status(202).send({ statusID: collectionId });
       }
       pdfCache.setExpectedLength(collectionId, requiredCalls);
       apiLogger.debug(`Queueing ${requiredCalls} for ${collectionId}`);
       for (let x = 0; x < Number(requiredCalls); x++) {
         const pdfDetails = getPdfRequestBody(requestConfigs[x]);
-        generatePdf(pdfDetails, collectionId, x + 1);
+        generatePdf(pdfDetails, collectionId, x + 1, authState);
       }
 
       return res.status(202).send({ statusID: collectionId });


### PR DESCRIPTION
### Description

[RHCLOUD-47965](https://issues.redhat.com/browse/RHCLOUD-47965)

Fixes PDF generation failures for large reports (e.g. 77-page vulnerability CVE exports) caused by three issues:

1. **Auth header not forwarded to internal proxies** — `createInternalProxies` now converts `x-pdf-auth` → `Authorization` on proxied requests.
2. **Errors swallowed by puppeteer-cluster** — `cluster.queue()` catches task errors via its own `taskerror` handler and does not propagate them. Error handling (status update, collection invalidation, page close) is now inside the queue callback so failures are properly recorded.
3. **JWT token expiry during long generation** — Added OIDC token refresh using the SSO `/token` endpoint. The refresh check runs at task execution time (not queue time), so tokens are refreshed right before use. A shared mutable `AuthState` object ensures all concurrent tasks see the refreshed token.

### How to test locally

1. Generate a large PDF (vulnerability CVE report with 50+ pages)
2. Confirm no 401 errors after token expiry (~5 min)
3. Confirm failed components show `Failed` status, not stuck on `Generating`
4. Confirm PDF generation still works without a refresh token header

### Anything reviewers should know?

- **Frontend change required**: `insights-chrome` needs to send the `x-rh-refresh-token` header for refresh to work. Without it, the service falls back to the original token (no regression). PR: https://github.com/RedHatInsights/insights-chrome/pull/3543.
- **App-interface MR**: SSO_URL config for stage/prod: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/189482
- `clowdapp.yml` adds `SSO_URL` and `SSO_CLIENT_ID` env vars.
- 

### Checklist

- [x] Tests — unit tests for token refresh (`tokenRefresh.spec.ts`) and cluster error handling (`clusterTask.spec.ts`)
- [ ] API — no API contract changes - only additions
- [x] Migrations — none
- [x] Dependencies — no new dependencies (uses built-in `fetch`)
- [x] Security — token refresh uses standard OIDC `refresh_token` grant; no secrets in code

### AI disclosure

This PR was developed with assistance from Claude Code (Anthropic).

[RHCLOUD-47965]: https://redhat.atlassian.net/browse/RHCLOUD-47965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ