### PR TITLE
fix(cache): resolve race conditions and improve reliability

### DIFF
--- a/src/browser/clusterTask.spec.ts
+++ b/src/browser/clusterTask.spec.ts
@@ -176,7 +176,9 @@ describe('generatePdf', () => {
       const req = makePdfRequest();
       initCollection('coll-err');
 
-      await generatePdf(req, 'coll-err', 1, makeAuthState());
+      await expect(
+        generatePdf(req, 'coll-err', 1, makeAuthState()),
+      ).rejects.toThrow('Page render error');
 
       expect(UpdateStatus).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -188,22 +190,26 @@ describe('generatePdf', () => {
       );
     });
 
-    it('invalidates the collection on render error', async () => {
+    it('throws error without invalidating collection (retry handled by cluster)', async () => {
       mockPage.evaluate.mockResolvedValue('Some error');
       initCollection('coll-inv');
       const pdfCache = PdfCache.getInstance();
       const spy = jest.spyOn(pdfCache, 'invalidateCollection');
 
-      await generatePdf(makePdfRequest(), 'coll-inv', 1, makeAuthState());
+      await expect(
+        generatePdf(makePdfRequest(), 'coll-inv', 1, makeAuthState()),
+      ).rejects.toThrow('Page render error');
 
-      expect(spy).toHaveBeenCalledWith('coll-inv', expect.any(String));
+      expect(spy).not.toHaveBeenCalled();
       spy.mockRestore();
     });
 
     it('closes the page after render error', async () => {
       mockPage.evaluate.mockResolvedValue('Error');
       initCollection('coll-close-err');
-      await generatePdf(makePdfRequest(), 'coll-close-err', 1, makeAuthState());
+      await expect(
+        generatePdf(makePdfRequest(), 'coll-close-err', 1, makeAuthState()),
+      ).rejects.toThrow();
       expect(mockPage.close).toHaveBeenCalled();
     });
   });
@@ -217,7 +223,9 @@ describe('generatePdf', () => {
       const req = makePdfRequest();
       initCollection('coll-500');
 
-      await generatePdf(req, 'coll-500', 1, makeAuthState());
+      await expect(
+        generatePdf(req, 'coll-500', 1, makeAuthState()),
+      ).rejects.toThrow('Puppeteer error');
 
       expect(UpdateStatus).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -233,7 +241,9 @@ describe('generatePdf', () => {
       const req = makePdfRequest();
       initCollection('coll-null');
 
-      await generatePdf(req, 'coll-null', 1, makeAuthState());
+      await expect(
+        generatePdf(req, 'coll-null', 1, makeAuthState()),
+      ).rejects.toThrow('Puppeteer error');
 
       expect(UpdateStatus).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -251,7 +261,9 @@ describe('generatePdf', () => {
       const req = makePdfRequest();
       initCollection('coll-timeout');
 
-      await generatePdf(req, 'coll-timeout', 1, makeAuthState());
+      await expect(
+        generatePdf(req, 'coll-timeout', 1, makeAuthState()),
+      ).rejects.toThrow('timeout');
 
       expect(UpdateStatus).toHaveBeenLastCalledWith(
         expect.objectContaining({

--- a/src/browser/clusterTask.ts
+++ b/src/browser/clusterTask.ts
@@ -271,7 +271,9 @@ async function runPageTask(
         order,
         error: message,
       });
-      PdfCache.getInstance().invalidateCollection(collectionId, message);
+      // Do not invalidate collection here - let cluster retries run first
+      // Collection invalidation happens in cluster.ts taskerror handler
+      throw taskError;
     } finally {
       await page.close().catch(() => {});
     }

--- a/src/common/kafka.ts
+++ b/src/common/kafka.ts
@@ -137,6 +137,7 @@ export async function consumeMessages(topic: string) {
           numPages: updateMessage?.numPages || 0,
           error: updateMessage?.error || `''`,
           order: updateMessage?.order,
+          expectedLength: cacheObject.expectedLength,
         });
       } catch (error) {
         apiLogger.debug(`Message sync error: ${JSON.stringify(error)}`);

--- a/src/common/pdfCache.spec.ts
+++ b/src/common/pdfCache.spec.ts
@@ -197,3 +197,110 @@ describe('Pdf Cache updates', () => {
     expect(added.status).toBe('Generating');
   });
 });
+
+function makeComponent(
+  collectionId: string,
+  componentId: string,
+  status: PdfStatus,
+  order: number,
+): PDFComponent {
+  return {
+    status,
+    filepath:
+      status === PdfStatus.Generated
+        ? `/tmp/report_${componentId}.pdf`
+        : '',
+    collectionId,
+    componentId,
+    numPages: status === PdfStatus.Generated ? 6 : 0,
+    error: status === PdfStatus.Failed ? 'some error' : "''",
+    order,
+  };
+}
+
+describe('verifyCollection non-blocking merge behavior', () => {
+  /**
+   * verifyCollection should trigger merge in background and return immediately,
+   * preventing status endpoint from blocking on large collection merges.
+   */
+  const pdfCache = PdfCache.getInstance();
+  const collectionId = 'non-blocking-merge-test-collection';
+
+  afterAll(() => {
+    pdfCache.clearAllTimers();
+  });
+
+  it('should return before merge completes', async () => {
+    let mergeStarted = false;
+    let mergeFinished = false;
+
+    const mergeSpy = jest
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .spyOn<PdfCache, any>(pdfCache, 'mergePDFsFromCompleteCollection')
+      .mockImplementation(async () => {
+        mergeStarted = true;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        mergeFinished = true;
+      });
+
+    pdfCache.setExpectedLength(collectionId, 3);
+    for (let i = 1; i <= 3; i++) {
+      pdfCache.addToCollection(
+        collectionId,
+        makeComponent(collectionId, `merge-comp-${i}`, PdfStatus.Generated, i),
+      );
+    }
+
+    await pdfCache.verifyCollection(collectionId);
+
+    expect(mergeStarted).toBe(true);
+    expect(mergeFinished).toBe(false);
+
+    mergeSpy.mockRestore();
+  });
+});
+
+describe('verifyCollection merge concurrency guard', () => {
+  /**
+   * Concurrent verifyCollection calls should trigger merge only once.
+   * Prevents duplicate merges when UpdateStatus and status endpoint
+   * both call verifyCollection simultaneously.
+   */
+  const pdfCache = PdfCache.getInstance();
+  const collectionId = 'merge-guard-test-collection';
+
+  afterAll(() => {
+    pdfCache.clearAllTimers();
+  });
+
+  it('should trigger merge only once for concurrent calls', async () => {
+    let mergeCallCount = 0;
+
+    const mergeSpy = jest
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .spyOn<PdfCache, any>(pdfCache, 'mergePDFsFromCompleteCollection')
+      .mockImplementation(async () => {
+        mergeCallCount++;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      });
+
+    pdfCache.setExpectedLength(collectionId, 2);
+    pdfCache.addToCollection(
+      collectionId,
+      makeComponent(collectionId, 'race-comp-1', PdfStatus.Generated, 1),
+    );
+    pdfCache.addToCollection(
+      collectionId,
+      makeComponent(collectionId, 'race-comp-2', PdfStatus.Generated, 2),
+    );
+
+    await Promise.all([
+      pdfCache.verifyCollection(collectionId),
+      pdfCache.verifyCollection(collectionId),
+    ]);
+
+    expect(mergeCallCount).toBe(1);
+
+    mergeSpy.mockRestore();
+  });
+});

--- a/src/common/pdfCache.spec.ts
+++ b/src/common/pdfCache.spec.ts
@@ -346,3 +346,39 @@ describe('expectedLength cross-pod sync via Kafka', () => {
     mockMerge.mockRestore();
   });
 });
+
+describe('invalidateCollection preserves component status', () => {
+  const pdfCache = PdfCache.getInstance();
+
+  afterAll(() => {
+    pdfCache.clearAllTimers();
+  });
+
+  it('should preserve component statuses when invalidating collection', () => {
+    const collectionId = 'preserve-status-collection';
+    pdfCache.setExpectedLength(collectionId, 3);
+    pdfCache.addToCollection(
+      collectionId,
+      makeComponent(collectionId, 'comp-success', PdfStatus.Generated, 1),
+    );
+    pdfCache.addToCollection(
+      collectionId,
+      makeComponent(collectionId, 'comp-fail', PdfStatus.Failed, 2),
+    );
+    pdfCache.addToCollection(
+      collectionId,
+      makeComponent(collectionId, 'comp-pending', PdfStatus.Generating, 3),
+    );
+
+    pdfCache.invalidateCollection(collectionId, 'Cluster retry exhausted');
+
+    const collection = pdfCache.getCollection(collectionId);
+    expect(collection.status).toBe(PdfStatus.Failed);
+    expect(collection.error).toBe('Cluster retry exhausted');
+
+    // Component statuses preserved (not overwritten to Failed)
+    expect(collection.components[0].status).toBe(PdfStatus.Generated);
+    expect(collection.components[1].status).toBe(PdfStatus.Failed);
+    expect(collection.components[2].status).toBe(PdfStatus.Generating);
+  });
+});

--- a/src/common/pdfCache.spec.ts
+++ b/src/common/pdfCache.spec.ts
@@ -1,10 +1,15 @@
 import PdfCache, { PDFComponent, PdfStatus } from './pdfCache';
 
 describe('Pdf Cache updates', () => {
+  const pdfCache = PdfCache.getInstance();
+
   beforeEach(() => {
     jest.resetAllMocks();
   });
-  const pdfCache = PdfCache.getInstance();
+
+  afterAll(() => {
+    pdfCache.clearAllTimers();
+  });
   const cache: PDFComponent = {
     status: PdfStatus.Failed,
     filepath: '',

--- a/src/common/pdfCache.spec.ts
+++ b/src/common/pdfCache.spec.ts
@@ -207,9 +207,7 @@ function makeComponent(
   return {
     status,
     filepath:
-      status === PdfStatus.Generated
-        ? `/tmp/report_${componentId}.pdf`
-        : '',
+      status === PdfStatus.Generated ? `/tmp/report_${componentId}.pdf` : '',
     collectionId,
     componentId,
     numPages: status === PdfStatus.Generated ? 6 : 0,
@@ -302,5 +300,49 @@ describe('verifyCollection merge concurrency guard', () => {
     expect(mergeCallCount).toBe(1);
 
     mergeSpy.mockRestore();
+  });
+});
+
+describe('expectedLength cross-pod sync via Kafka', () => {
+  /**
+   * Simulates pod receiving component updates via Kafka without
+   * the setExpectedLength call (which only runs on the create handler pod).
+   */
+  const pdfCache = PdfCache.getInstance();
+  const collectionId = 'kafka-sync-test-collection';
+
+  afterAll(() => {
+    pdfCache.clearAllTimers();
+  });
+
+  it('should apply expectedLength from Kafka messages', async () => {
+    const mockMerge = jest
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .spyOn<PdfCache, any>(pdfCache, 'mergePDFsFromCompleteCollection')
+      .mockImplementation(async () => {});
+
+    // Simulate Kafka consumer receiving components with expectedLength piggybacked
+    for (let i = 1; i <= 5; i++) {
+      const component = makeComponent(
+        collectionId,
+        `comp-${i}`,
+        PdfStatus.Generated,
+        i,
+      );
+      // Add expectedLength to component (simulating Kafka message payload)
+      component.expectedLength = 5;
+      pdfCache.addToCollection(collectionId, component);
+    }
+
+    const collection = pdfCache.getCollection(collectionId);
+    expect(collection.expectedLength).toBe(5);
+    expect(collection.components.length).toBe(5);
+
+    await pdfCache.verifyCollection(collectionId);
+
+    // Should transition to Generated (not stuck at Generating)
+    expect(mockMerge).toHaveBeenCalledWith(collectionId);
+
+    mockMerge.mockRestore();
   });
 });

--- a/src/common/pdfCache.ts
+++ b/src/common/pdfCache.ts
@@ -60,6 +60,7 @@ export type PDFComponentGroup = {
   expectedLength: number;
   status: PdfStatus;
   error?: string;
+  merging?: boolean;
 };
 export type PDFComponent = {
   status: PdfStatus;
@@ -257,10 +258,24 @@ class PdfCache {
     }
 
     if (this.allComponentsGenerated(collectionId, components)) {
-      // Everything is generated and looks good, kick off an async job
-      // to store them in a single PDF
-      await this.mergePDFsFromCompleteCollection(collectionId);
-      this.updateCollectionState(collectionId, PdfStatus.Generated);
+      // Guard against concurrent merge attempts
+      if (this.data[collectionId].merging) {
+        return;
+      }
+      this.data[collectionId].merging = true;
+
+      // Fire-and-forget: merge in background without blocking
+      const mergePromise = this.mergePDFsFromCompleteCollection(collectionId);
+      if (mergePromise) {
+        mergePromise
+          .then(() => {
+            this.updateCollectionState(collectionId, PdfStatus.Generated);
+          })
+          .catch((error) => {
+            apiLogger.error(`Merge failed for ${collectionId}: ${error}`);
+            this.data[collectionId].merging = false;
+          });
+      }
     }
   }
 

--- a/src/common/pdfCache.ts
+++ b/src/common/pdfCache.ts
@@ -70,6 +70,7 @@ export type PDFComponent = {
   error?: string;
   numPages?: number;
   order?: number;
+  expectedLength?: number;
 };
 
 const addPageNumbers = async (pdfBuffer: Uint8Array): Promise<Uint8Array> => {
@@ -141,6 +142,15 @@ class PdfCache {
       ({ componentId }) => componentId !== status.componentId,
     );
     this.data[collectionId].components.push(status);
+
+    // Apply expectedLength if present in component (piggybacked from Kafka)
+    if (
+      status.expectedLength !== undefined &&
+      status.expectedLength > 0 &&
+      this.data[collectionId].expectedLength === 0
+    ) {
+      this.data[collectionId].expectedLength = status.expectedLength;
+    }
   }
 
   public getCollection(id: string): PDFComponentGroup {

--- a/src/common/pdfCache.ts
+++ b/src/common/pdfCache.ts
@@ -103,9 +103,11 @@ const addPageNumbers = async (pdfBuffer: Uint8Array): Promise<Uint8Array> => {
 class PdfCache {
   private static instance: PdfCache;
   private data: PdfCollection;
+  private timers: Map<string, NodeJS.Timeout>;
 
   private constructor() {
     this.data = {};
+    this.timers = new Map();
   }
 
   public static getInstance(): PdfCache {
@@ -145,6 +147,11 @@ class PdfCache {
   }
 
   public deleteCollection(id: string) {
+    const timer = this.timers.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      this.timers.delete(id);
+    }
     delete this.data[id];
   }
 
@@ -273,16 +280,33 @@ class PdfCache {
   }
 
   public cleanExpiredCollection(uuid: string) {
+    // Clear any existing timer for this collection
+    const existingTimer = this.timers.get(uuid);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+    }
+
     apiLogger.debug(
       `Timeout for ${uuid} has been set to ${formatTimeToEnglish(
         ENTRY_TIMEOUT,
       )}`,
     );
-    setTimeout(() => {
+    const timer = setTimeout(() => {
       // This should potentially also call the objectStore to remove the PDF(s)
       apiLogger.debug(`Removing expired collection ${uuid}`);
       this.deleteCollection(uuid);
     }, ENTRY_TIMEOUT);
+
+    // Allow Node to exit even if this timer is still pending
+    timer.unref();
+    this.timers.set(uuid, timer);
+  }
+
+  public clearAllTimers(): void {
+    for (const timer of this.timers.values()) {
+      clearTimeout(timer);
+    }
+    this.timers.clear();
   }
 
   // After all slices of a PDF have been marked as "Generated", we can

--- a/src/common/pdfCache.ts
+++ b/src/common/pdfCache.ts
@@ -200,19 +200,22 @@ class PdfCache {
     collectionId: string,
     status: PdfStatus,
     error?: string,
+    overwriteComponentStatus = true,
   ): void {
     if (!this.data[collectionId]) {
       throw new Error('Collection not found');
     }
 
-    this.data[collectionId].components = this.data[collectionId].components.map(
-      (component) => {
+    if (overwriteComponentStatus) {
+      this.data[collectionId].components = this.data[
+        collectionId
+      ].components.map((component) => {
         return {
           ...component,
           status,
         };
-      },
-    );
+      });
+    }
     this.data[collectionId].status = status;
     this.data[collectionId].error = error;
   }
@@ -237,7 +240,7 @@ class PdfCache {
   }
 
   public invalidateCollection(collectionId: string, error: string): void {
-    this.updateCollectionState(collectionId, PdfStatus.Failed, error);
+    this.updateCollectionState(collectionId, PdfStatus.Failed, error, false);
   }
 
   public async verifyCollection(collectionId: string): Promise<void> {

--- a/src/server/cluster.ts
+++ b/src/server/cluster.ts
@@ -3,6 +3,7 @@ import config from '../common/config';
 const BROWSER_TIMEOUT = 120_000;
 import { CHROMIUM_PATH } from '../browser/helpers';
 import { apiLogger } from '../common/logging';
+import PdfCache from '../common/pdfCache';
 
 export const GetPupCluster = async () => {
   const CONCURRENCY_DEFAULT = 2;
@@ -39,6 +40,16 @@ export const GetPupCluster = async () => {
   // Add error handlers to prevent unhandled rejections from cluster tasks
   cluster.on('taskerror', (err: Error, data: unknown) => {
     apiLogger.error('Puppeteer cluster task error:', err, 'data:', data);
+
+    // After all retries exhausted, invalidate the entire collection
+    if (data && typeof data === 'object' && 'collectionId' in data) {
+      const collectionId = (data as { collectionId: string }).collectionId;
+      const message = err instanceof Error ? err.message : String(err);
+      apiLogger.error(
+        `Collection ${collectionId} failed after retries: ${message}`,
+      );
+      PdfCache.getInstance().invalidateCollection(collectionId, message);
+    }
   });
 
   return cluster;

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -7,7 +7,12 @@ const pdfCache = PdfCache.getInstance();
 
 export const UpdateStatus = async (updateMessage: PDFComponent) => {
   pdfCache.addToCollection(updateMessage.collectionId, updateMessage);
-  await produceMessage(UPDATE_TOPIC, updateMessage)
+  const collection = pdfCache.getCollection(updateMessage.collectionId);
+  const messageWithLength = {
+    ...updateMessage,
+    expectedLength: collection?.expectedLength || 0,
+  };
+  await produceMessage(UPDATE_TOPIC, messageWithLength)
     .then(() => {
       apiLogger.debug('Generating message sent');
     })


### PR DESCRIPTION
## Description

  Fixes several race conditions and reliability issues in PDF cache management:

  1. Timer cleanup in tests - Prevents test hangs from leaked timers by adding proper cleanup
  2. Merge concurrency guard - Prevents duplicate merge operations when multiple requests hit same collection simultaneously within a pod
  3. Cross-pod expectedLength sync - Syncs expectedLength via Kafka status messages so all pods know collection size
  4. Preserve component status on collection failure - Throws errors for cluster retry instead of immediately invalidating collection, preserving individual component status

  These fixes address intermittent PDF generation failures caused by race conditions in concurrent request handling.

[RHCLOUD-47965](https://redhat.atlassian.net/browse/RHCLOUD-47965)

  ---
 ## How to test locally

**Use Google Chrome.**

### vulnerability-ui

Set `_unstableSpdy: false` in `fec.config.js` then run:

```sh
LOCAL_PDF_GENERATOR=true npm run start -- --clouddotEnv=stage
```

### minio & kafka

```sh
cd pdf-generator
podman compose up
```

### pdf-generator

Create `.env` file. 

```.env
MINIO_ACCESS_KEY="minioadmin"
MINIO_SECRET_KEY="minioadmin"
MAX_CONCURRENCY=1
SSO_URL=https://sso.stage.redhat.com/auth/
LOG_LEVEL=warning
```

Then run:

```sh
ASSETS_HOST=https://stage.foo.redhat.com:1337/ API_HOST=https://stage.foo.redhat.com:1337/ npm run start:server
```

Navigate to `RHEL > Security > Vulnerabilities > Reports` and generate a CVE report. 

  ---
  Anything reviewers should know?

  - throw taskError in clusterTask.ts allows cluster retry mechanism to work before invalidating collection
  - Merge guard uses boolean flag; concurrent callers return immediately if merge already in progress
  - Kafka sync piggybacks expectedLength on existing status messages (no new topic)
  - Timer cleanup only affects tests; production code unchanged

  ---
  Checklist

  - [x] Tests: new/updated tests cover the change
  - [ ] API: spec updated if endpoints changed (or N/A)
  - [ ] Migrations: backwards compatible if schema changed (or N/A)
  - [x] Dependencies: no known impact to dependent services
  - [x] Security: reviewed against secure coding checklist (or N/A)

  AI disclosure

  Assisted by: Claude Code

[RHCLOUD-47965]: https://redhat.atlassian.net/browse/RHCLOUD-47965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ