### PR TITLE
feat(auth): add reactive token refresh on 401 responses

### DIFF
--- a/src/browser/clusterTask.spec.ts
+++ b/src/browser/clusterTask.spec.ts
@@ -19,8 +19,11 @@ const mockPage = {
 
 jest.mock('../server/cluster', () => ({
   cluster: {
-    queue: jest.fn((taskFn: ({ page }: { page: unknown }) => Promise<void>) =>
-      taskFn({ page: mockPage }),
+    queue: jest.fn(
+      (
+        _taskData: unknown,
+        taskFn: ({ page }: { page: unknown }) => Promise<void>,
+      ) => taskFn({ page: mockPage }),
     ),
   },
 }));
@@ -44,6 +47,7 @@ jest.mock('../common/logging', () => ({
     debug: jest.fn(),
     info: jest.fn(),
     error: jest.fn(),
+    warn: jest.fn(),
     warning: jest.fn(),
   },
 }));
@@ -176,7 +180,9 @@ describe('generatePdf', () => {
       const req = makePdfRequest();
       initCollection('coll-err');
 
-      await generatePdf(req, 'coll-err', 1, makeAuthState());
+      await expect(
+        generatePdf(req, 'coll-err', 1, makeAuthState()),
+      ).rejects.toThrow('Page render error');
 
       expect(UpdateStatus).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -188,22 +194,26 @@ describe('generatePdf', () => {
       );
     });
 
-    it('invalidates the collection on render error', async () => {
+    it('throws error without invalidating collection (retry handled by cluster)', async () => {
       mockPage.evaluate.mockResolvedValue('Some error');
       initCollection('coll-inv');
       const pdfCache = PdfCache.getInstance();
       const spy = jest.spyOn(pdfCache, 'invalidateCollection');
 
-      await generatePdf(makePdfRequest(), 'coll-inv', 1, makeAuthState());
+      await expect(
+        generatePdf(makePdfRequest(), 'coll-inv', 1, makeAuthState()),
+      ).rejects.toThrow('Page render error');
 
-      expect(spy).toHaveBeenCalledWith('coll-inv', expect.any(String));
+      expect(spy).not.toHaveBeenCalled();
       spy.mockRestore();
     });
 
     it('closes the page after render error', async () => {
       mockPage.evaluate.mockResolvedValue('Error');
       initCollection('coll-close-err');
-      await generatePdf(makePdfRequest(), 'coll-close-err', 1, makeAuthState());
+      await expect(
+        generatePdf(makePdfRequest(), 'coll-close-err', 1, makeAuthState()),
+      ).rejects.toThrow();
       expect(mockPage.close).toHaveBeenCalled();
     });
   });
@@ -217,7 +227,9 @@ describe('generatePdf', () => {
       const req = makePdfRequest();
       initCollection('coll-500');
 
-      await generatePdf(req, 'coll-500', 1, makeAuthState());
+      await expect(
+        generatePdf(req, 'coll-500', 1, makeAuthState()),
+      ).rejects.toThrow('Puppeteer error');
 
       expect(UpdateStatus).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -233,7 +245,9 @@ describe('generatePdf', () => {
       const req = makePdfRequest();
       initCollection('coll-null');
 
-      await generatePdf(req, 'coll-null', 1, makeAuthState());
+      await expect(
+        generatePdf(req, 'coll-null', 1, makeAuthState()),
+      ).rejects.toThrow('Puppeteer error');
 
       expect(UpdateStatus).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -251,7 +265,9 @@ describe('generatePdf', () => {
       const req = makePdfRequest();
       initCollection('coll-timeout');
 
-      await generatePdf(req, 'coll-timeout', 1, makeAuthState());
+      await expect(
+        generatePdf(req, 'coll-timeout', 1, makeAuthState()),
+      ).rejects.toThrow('timeout');
 
       expect(UpdateStatus).toHaveBeenLastCalledWith(
         expect.objectContaining({
@@ -284,7 +300,7 @@ describe('generatePdf', () => {
   });
 
   describe('token refresh integration', () => {
-    it('refreshes token before setting headers when expiring', async () => {
+    it('refreshes token before setting headers when expiring (proactive)', async () => {
       isTokenExpiringSoon.mockReturnValue(true);
       refreshAccessToken.mockResolvedValue({
         accessToken: 'Bearer refreshed-token',
@@ -300,6 +316,56 @@ describe('generatePdf', () => {
       expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
         expect.objectContaining({
           'x-pdf-auth': 'Bearer refreshed-token',
+        }),
+      );
+    });
+
+    it('refreshes token after 401 response detected (reactive)', async () => {
+      type Response = {
+        status: () => number;
+        url: () => string;
+        ok: () => boolean;
+      };
+
+      type ResponseHandler = (response: Response) => Promise<void>;
+
+      isTokenExpiringSoon.mockReturnValue(false);
+      refreshAccessToken.mockResolvedValue({
+        accessToken: 'Bearer refreshed-after-401',
+      });
+      const authState = makeAuthState({ authHeader: 'Bearer original-token' });
+
+      // Capture ALL response handlers (there are 2: 401 tracker + asset cache)
+      const responseHandlers: ResponseHandler[] = [];
+      mockPage.on.mockImplementation(
+        (event: string, handler: ResponseHandler) => {
+          if (event === 'response') {
+            responseHandlers.push(handler);
+          }
+        },
+      );
+
+      mockPage.goto.mockImplementation(async () => {
+        // Trigger 401 via first response handler (401 tracker)
+        if (responseHandlers[0]) {
+          await responseHandlers[0]({
+            status: () => 401,
+            url: () => 'http://api/endpoint',
+            ok: () => false,
+          });
+        }
+        return { status: () => 200, statusText: () => 'OK' };
+      });
+
+      await generatePdf(makePdfRequest(), 'coll-reactive', 1, authState);
+
+      expect(refreshAccessToken).toHaveBeenCalledWith(
+        'Bearer some-refresh-token',
+      );
+      expect(authState.authHeader).toBe('Bearer refreshed-after-401');
+      expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'x-pdf-auth': 'Bearer refreshed-after-401',
         }),
       );
     });

--- a/src/browser/clusterTask.ts
+++ b/src/browser/clusterTask.ts
@@ -39,243 +39,283 @@ async function runPageTask(
   pdfPath: string,
   authState: AuthState,
 ): Promise<void> {
-  await cluster.queue(async ({ page }: { page: Page }) => {
-    if (PdfCache.getInstance().isCollectionFailed(collectionId)) {
-      apiLogger.debug(
-        `Skipping component ${componentId}: collection ${collectionId} already failed`,
-      );
-      await UpdateStatus({
-        collectionId,
-        status: PdfStatus.Failed,
-        filepath: '',
-        componentId,
-        order,
-        error: 'Collection failed before this component started',
-      });
-      return;
-    }
-
-    try {
-      await UpdateStatus({
-        status: PdfStatus.Generating,
-        filepath: '',
-        order,
-        componentId,
-        collectionId,
-      });
-      await page.setViewport({ width: pageWidth, height: pageHeight });
-      page.on('console', (msg) =>
-        apiLogger.info(`[Headless log] ${msg.text()}`),
-      );
-
-      page.on('response', async (response) => {
-        if (response.status() >= 400) {
-          let body = '';
-          try {
-            body = await response.text();
-          } catch {
-            body = '<unreadable>';
-          }
-          apiLogger.debug(
-            `[Headless response] ${response.status()} ${response.url()} | body=${body}`,
-          );
-        }
-      });
-
-      await setWindowProperty(
-        page,
-        'customPuppeteerParams',
-        JSON.stringify({
-          puppeteerParams: {
-            pageWidth,
-            pageHeight,
-          },
-        }),
-      );
-
-      // Refresh token if expiring before setting headers
-      if (
-        authState.refreshToken &&
-        authState.authHeader &&
-        isTokenExpiringSoon(authState.authHeader.replace(/^Bearer\s+/i, ''))
-      ) {
-        apiLogger.debug(
-          `[token-refresh] Refreshing before component ${componentId}`,
-        );
-        const refreshed = await refreshAccessToken(authState.refreshToken);
-        if (refreshed) {
-          authState.authHeader = refreshed.accessToken;
-        }
-      }
-
-      const extraHeaders: Record<string, string> = {};
-      if (identity) {
-        extraHeaders['x-rh-identity'] = identity;
-      }
-
-      if (fetchDataParams) {
-        extraHeaders[config?.OPTIONS_HEADER_NAME] =
-          JSON.stringify(fetchDataParams);
-      }
-
-      if (authState.authHeader) {
-        extraHeaders[config.AUTHORIZATION_CONTEXT_KEY] = authState.authHeader;
-      }
-
-      if (authState.authCookie) {
-        await page.setCookie({
-          name: config.JWT_COOKIE_NAME,
-          value: authState.authCookie,
-          domain: 'localhost',
-        });
-      }
-
-      await page.setRequestInterception(true);
-      page.on('request', async (interceptedRequest) => {
-        const reqUrl = interceptedRequest.url();
-        if (
-          interceptedRequest.method() === 'GET' &&
-          reqUrl.includes('/apps/') &&
-          /\.(js|css)(\?|$)/.test(reqUrl)
-        ) {
-          const cached = assetCache.get(assetCacheKey(reqUrl));
-          if (cached) {
-            await interceptedRequest.respond({
-              status: 200,
-              contentType: cached.contentType,
-              body: cached.body,
-            });
-            return;
-          }
-        }
-        await interceptedRequest.continue();
-      });
-
-      page.on('response', async (resp) => {
-        const respUrl = resp.url();
-        if (
-          resp.ok() &&
-          respUrl.includes('/apps/') &&
-          /\.(js|css)(\?|$)/.test(respUrl) &&
-          !assetCache.has(assetCacheKey(respUrl))
-        ) {
-          try {
-            const body = await resp.buffer();
-            assetCache.set(assetCacheKey(respUrl), {
-              body,
-              contentType:
-                resp.headers()['content-type'] ||
-                (respUrl.match(/\.css(\?|$)/)
-                  ? 'text/css'
-                  : 'application/javascript'),
-            });
-          } catch {
-            // response body may not be available
-          }
-        }
-      });
-
-      await page.setExtraHTTPHeaders(extraHeaders);
-
-      const pageResponse = await page.goto(url, {
-        waitUntil: 'networkidle2',
-        timeout: BROWSER_TIMEOUT,
-      });
-      await page.waitForNetworkIdle({
-        idleTime: 1000,
-      });
-      const pageStatus = pageResponse?.status();
-
-      const error = await page.evaluate(() => {
-        const appError = document.getElementById('crc-pdf-generator-err');
-        if (appError) {
-          return appError.innerText;
-        }
-        const templateError = document.getElementById('report-error');
-        if (templateError) {
-          return templateError.innerText;
-        }
-      });
-
-      if (error && error.length > 0) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let response: any;
-        try {
-          response = JSON.parse(error);
-          apiLogger.debug(response.data);
-        } catch {
-          response = error;
-          apiLogger.debug(`Page render error ${response}`);
-        }
-        throw new PdfGenerationError(
-          collectionId,
-          componentId,
-          `Page render error: ${response}`,
-        );
-      }
-      if (!pageStatus || !isValidPageResponse(pageStatus)) {
-        apiLogger.debug(`Page status: ${pageResponse?.statusText()}`);
-        throw new PdfGenerationError(
-          collectionId,
-          componentId,
-          `Puppeteer error while loading the react app: ${pageResponse?.statusText()}`,
-        );
-      }
-
+  await cluster.queue(
+    { collectionId, componentId },
+    async ({ page }: { page: Page }) => {
       if (PdfCache.getInstance().isCollectionFailed(collectionId)) {
         apiLogger.debug(
-          `Aborting component ${componentId}: collection ${collectionId} failed during page load`,
+          `Skipping component ${componentId}: collection ${collectionId} already failed`,
         );
+        await UpdateStatus({
+          collectionId,
+          status: PdfStatus.Failed,
+          filepath: '',
+          componentId,
+          order,
+          error: 'Collection failed before this component started',
+        });
         return;
       }
 
-      const { headerTemplate, footerTemplate } = getHeaderAndFooterTemplates();
+      try {
+        await UpdateStatus({
+          status: PdfStatus.Generating,
+          filepath: '',
+          order,
+          componentId,
+          collectionId,
+        });
+        await page.setViewport({ width: pageWidth, height: pageHeight });
+        page.on('console', (msg) => {
+          apiLogger.debug(`[Headless log] ${msg.text()}`);
+        });
 
-      const buffer = await page.pdf({
-        path: pdfPath,
-        format: 'a4',
-        printBackground: true,
-        margin: {
-          top: '54px',
-          bottom: '54px',
-        },
-        landscape,
-        displayHeaderFooter: true,
-        headerTemplate,
-        footerTemplate,
-        timeout: BROWSER_TIMEOUT,
-      });
-      await store.uploadPDF(componentId, pdfPath).catch((error: unknown) => {
-        apiLogger.error(`Failed to upload PDF: ${error}`);
-      });
-      const pdfDoc = await PDFDocument.load(buffer);
-      const numPages = pdfDoc.getPages().length;
-      apiLogger.debug(`Generated PDF with ${numPages} pages`);
-      await UpdateStatus({
-        collectionId,
-        status: PdfStatus.Generated,
-        filepath: pdfPath,
-        componentId,
-        numPages,
-        order,
-      });
-    } catch (taskError: unknown) {
-      const message =
-        taskError instanceof Error ? taskError.message : String(taskError);
-      apiLogger.error(`Component ${componentId} failed: ${message}`);
-      await UpdateStatus({
-        collectionId,
-        status: PdfStatus.Failed,
-        filepath: '',
-        componentId,
-        order,
-        error: message,
-      });
-      PdfCache.getInstance().invalidateCollection(collectionId, message);
-    } finally {
-      await page.close().catch(() => {});
-    }
-  });
+        // Track 401 responses during page load and API requests for token refresh
+        let unauthorized = false;
+        page.on('response', async (response) => {
+          if (response.status() === 401) {
+            unauthorized = true;
+          }
+          if (response.status() >= 400) {
+            let body = '';
+            try {
+              body = await response.text();
+            } catch {
+              body = '<unreadable>';
+            }
+            apiLogger.debug(
+              `[Headless response] ${response.status()} ${response.url()} | body=${body}`,
+            );
+          }
+        });
+
+        await setWindowProperty(
+          page,
+          'customPuppeteerParams',
+          JSON.stringify({
+            puppeteerParams: {
+              pageWidth,
+              pageHeight,
+            },
+          }),
+        );
+
+        // Refresh token if expiring before setting headers
+        // Updated authState.authHeader will be picked up when extraHeaders is built below
+        if (
+          authState.authHeader &&
+          isTokenExpiringSoon(authState.authHeader.replace(/^Bearer\s+/i, ''))
+        ) {
+          if (!authState.refreshToken) {
+            apiLogger.warn(
+              `[token-refresh] Access token expiring for component ${componentId} but no refresh token available`,
+            );
+          } else {
+            apiLogger.debug(
+              `[token-refresh] Refreshing before component ${componentId}`,
+            );
+            const refreshed = await refreshAccessToken(authState.refreshToken);
+            if (refreshed) {
+              authState.authHeader = refreshed.accessToken;
+            }
+            // tokenRefresh.ts already logs specific failure reason
+          }
+        }
+
+        const extraHeaders: Record<string, string> = {};
+        if (identity) {
+          extraHeaders['x-rh-identity'] = identity;
+        }
+
+        if (fetchDataParams) {
+          extraHeaders[config?.OPTIONS_HEADER_NAME] =
+            JSON.stringify(fetchDataParams);
+        }
+
+        if (authState.authHeader) {
+          extraHeaders[config.AUTHORIZATION_CONTEXT_KEY] = authState.authHeader;
+        }
+
+        if (authState.authCookie) {
+          await page.setCookie({
+            name: config.JWT_COOKIE_NAME,
+            value: authState.authCookie,
+            domain: 'localhost',
+          });
+        }
+
+        await page.setRequestInterception(true);
+        page.on('request', async (interceptedRequest) => {
+          const reqUrl = interceptedRequest.url();
+          if (
+            interceptedRequest.method() === 'GET' &&
+            reqUrl.includes('/apps/') &&
+            /\.(js|css)(\?|$)/.test(reqUrl)
+          ) {
+            const cached = assetCache.get(assetCacheKey(reqUrl));
+            if (cached) {
+              await interceptedRequest.respond({
+                status: 200,
+                contentType: cached.contentType,
+                body: cached.body,
+              });
+              return;
+            }
+          }
+          await interceptedRequest.continue();
+        });
+
+        page.on('response', async (resp) => {
+          const respUrl = resp.url();
+          if (
+            resp.ok() &&
+            respUrl.includes('/apps/') &&
+            /\.(js|css)(\?|$)/.test(respUrl) &&
+            !assetCache.has(assetCacheKey(respUrl))
+          ) {
+            try {
+              const body = await resp.buffer();
+              assetCache.set(assetCacheKey(respUrl), {
+                body,
+                contentType:
+                  resp.headers()['content-type'] ||
+                  (respUrl.match(/\.css(\?|$)/)
+                    ? 'text/css'
+                    : 'application/javascript'),
+              });
+            } catch {
+              // response body may not be available
+            }
+          }
+        });
+
+        await page.setExtraHTTPHeaders(extraHeaders);
+
+        const pageResponse = await page.goto(url, {
+          waitUntil: 'networkidle2',
+          timeout: BROWSER_TIMEOUT,
+        });
+        await page.waitForNetworkIdle({
+          idleTime: 1000,
+        });
+
+        // If 401 detected from API requests and refresh token available, update headers for subsequent requests
+        if (unauthorized) {
+          if (!authState.refreshToken) {
+            apiLogger.warn(
+              `[token-refresh] 401 detected for component ${componentId} but no refresh token available`,
+            );
+          } else {
+            apiLogger.debug(
+              `[token-refresh] 401 detected for component ${componentId}, refreshing token for subsequent requests`,
+            );
+            const refreshed = await refreshAccessToken(authState.refreshToken);
+            if (refreshed) {
+              authState.authHeader = refreshed.accessToken;
+              extraHeaders[config.AUTHORIZATION_CONTEXT_KEY] =
+                refreshed.accessToken;
+              await page.setExtraHTTPHeaders(extraHeaders);
+            }
+            // tokenRefresh.ts already logs specific failure reason
+          }
+        }
+
+        const pageStatus = pageResponse?.status();
+
+        const error = await page.evaluate(() => {
+          const appError = document.getElementById('crc-pdf-generator-err');
+          if (appError) {
+            return appError.innerText;
+          }
+          const templateError = document.getElementById('report-error');
+          if (templateError) {
+            return templateError.innerText;
+          }
+        });
+
+        if (error && error.length > 0) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          let response: any;
+          try {
+            response = JSON.parse(error);
+            apiLogger.debug(response.data);
+          } catch {
+            response = error;
+            apiLogger.debug(`Page render error ${response}`);
+          }
+          throw new PdfGenerationError(
+            collectionId,
+            componentId,
+            `Page render error: ${response}`,
+          );
+        }
+        if (!pageStatus || !isValidPageResponse(pageStatus)) {
+          apiLogger.debug(`Page status: ${pageResponse?.statusText()}`);
+          throw new PdfGenerationError(
+            collectionId,
+            componentId,
+            `Puppeteer error while loading the react app: ${pageResponse?.statusText()}`,
+          );
+        }
+
+        if (PdfCache.getInstance().isCollectionFailed(collectionId)) {
+          apiLogger.debug(
+            `Aborting component ${componentId}: collection ${collectionId} failed during page load`,
+          );
+          return;
+        }
+
+        const { headerTemplate, footerTemplate } =
+          getHeaderAndFooterTemplates();
+
+        const buffer = await page.pdf({
+          path: pdfPath,
+          format: 'a4',
+          printBackground: true,
+          margin: {
+            top: '54px',
+            bottom: '54px',
+          },
+          landscape,
+          displayHeaderFooter: true,
+          headerTemplate,
+          footerTemplate,
+          timeout: BROWSER_TIMEOUT,
+        });
+        await store.uploadPDF(componentId, pdfPath).catch((error: unknown) => {
+          apiLogger.error(`Failed to upload PDF: ${error}`);
+        });
+        const pdfDoc = await PDFDocument.load(buffer);
+        const numPages = pdfDoc.getPages().length;
+        apiLogger.debug(`Generated PDF with ${numPages} pages`);
+        await UpdateStatus({
+          collectionId,
+          status: PdfStatus.Generated,
+          filepath: pdfPath,
+          componentId,
+          numPages,
+          order,
+        });
+      } catch (taskError: unknown) {
+        const message =
+          taskError instanceof Error ? taskError.message : String(taskError);
+        apiLogger.error(`Component ${componentId} failed: ${message}`);
+        await UpdateStatus({
+          collectionId,
+          status: PdfStatus.Failed,
+          filepath: '',
+          componentId,
+          order,
+          error: message,
+        });
+        // Do not invalidate collection here - let cluster retries run first
+        // Collection invalidation happens in cluster.ts taskerror handler
+        throw taskError;
+      } finally {
+        await page.close().catch(() => {});
+      }
+    },
+  );
 }
 
 export const generatePdf = async (

--- a/src/common/pdfCache.ts
+++ b/src/common/pdfCache.ts
@@ -187,14 +187,16 @@ class PdfCache {
       throw new Error('Collection not found');
     }
 
-    this.data[collectionId].components = this.data[collectionId].components.map(
-      (component) => {
+    if (overwriteComponentStatus) {
+      this.data[collectionId].components = this.data[
+        collectionId
+      ].components.map((component) => {
         return {
           ...component,
           status,
         };
-      },
-    );
+      });
+    }
     this.data[collectionId].status = status;
     this.data[collectionId].error = error;
   }

--- a/src/server/routes/routes.ts
+++ b/src/server/routes/routes.ts
@@ -86,7 +86,6 @@ function addProxy(req: GenerateHandlerRequest) {
         preserveHeaderKeyCase: true,
         on: {
           proxyReq: (proxyReq) => {
-            console.log('THIS SHOULD NOT BE HERE');
             const authHeader = proxyReq.getHeader(
               config.AUTHORIZATION_CONTEXT_KEY,
             );


### PR DESCRIPTION
Description

  Adds reactive token refresh during PDF generation to handle token expiry during API calls, complementing existing proactive refresh at page load.

  Before: Only checked token expiry proactively before page load. If token expired during subsequent API requests, generation failed with 401.

  After:
  - Proactive refresh - Still checks token expiry before page load and refreshes if needed
  - Reactive refresh - Detects 401 responses during page load/API calls and refreshes token for retry

  This prevents PDF generation failures when tokens expire mid-generation (common for multi-component PDFs with long processing times).

  Also removes debug console.log statements.

  Depends on: RHINENG-24661-a (cache reliability fixes) - requires throw taskError behavior

[  RHCLOUD-47965](https://redhat.atlassian.net/browse/RHCLOUD-47965)

  ---
## How to test locally

**Use Google Chrome.**

### vulnerability-ui

Set `_unstableSpdy: false` in `fec.config.js` then run:

```sh
LOCAL_PDF_GENERATOR=true npm run start -- --clouddotEnv=stage
```

### minio & kafka

```sh
cd pdf-generator
podman compose up
```

### pdf-generator

Create `.env` file. 

```.env
MINIO_ACCESS_KEY="minioadmin"
MINIO_SECRET_KEY="minioadmin"
MAX_CONCURRENCY=1
SSO_URL=https://sso.stage.redhat.com/auth/
LOG_LEVEL=warning
```

Then run:

```sh
ASSETS_HOST=https://stage.foo.redhat.com:1337/ API_HOST=https://stage.foo.redhat.com:1337/ npm run start:server
```

Navigate to `RHEL > Security > Vulnerabilities > Reports` and generate a CVE report. 

  ---
  Anything reviewers should know?

  - unauthorized flag tracks 401s from response handler (fires before page.goto returns)
  - Reactive refresh updates extraHeaders and calls setExtraHTTPHeaders for subsequent requests on same page
  - Both proactive and reactive paths check for authState.refreshToken availability before attempting refresh
  - tokenRefresh.ts module handles actual refresh logic and logging
  - Tests mock 401 responses and verify refresh triggered correctly

  ---
  Checklist

  - [x] Tests: new/updated tests cover the change
  - [ ] API: spec updated if endpoints changed (or N/A)
  - [ ] Migrations: backwards compatible if schema changed (or N/A)
  - [x] Dependencies: no known impact to dependent services
  - [x] Security: reviewed against secure coding checklist (or N/A)

  AI disclosure

  Assisted by: Claude Code