### PR TITLE
fix(server): increase max listeners to 20 for middleware stack

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -30,7 +30,14 @@ app.use('/', router);
 PdfCache.getInstance();
 store.intialize(StoreType.S3);
 
-const server = http.createServer({}, app).listen(PORT, () => {
+const server = http.createServer({}, app);
+
+// Increase max listeners to accommodate multiple middleware/handlers
+// (express-prom-bundle, http-context, static handlers, error handlers)
+// Default is 10, saw 11 in production logs
+server.setMaxListeners(20);
+
+server.listen(PORT, () => {
   apiLogger.info(`Listening on port ${PORT}`);
   consumeMessages(UPDATE_TOPIC).catch((error: unknown) => {
     apiLogger.error(`${error}`);


### PR DESCRIPTION
Description
   
  Fixes MaxListenersExceededWarning appearing in production logs at pod startup. The HTTP server was receiving 11 close event listeners (exceeding the Node.js default limit of 10) due to multiple middleware and handlers attaching to the server lifecycle.

  Increased max listeners to 20 to accommodate the middleware stack: express-prom-bundle, http-context, static handlers, cookie-parser, and custom error handlers.

  RHCLOUD-48985

  ---
  Anything reviewers should know?

  - Harmless warning but indicates potential for unintended side effects if more listeners are added in future
  - Limit set to 20 (2x current count) to provide headroom
  - No functional change to server behavior, only suppresses warning
  - Two HTTP servers exist: main API + dedicated metrics server, both attach listeners

  ---
  Checklist

  - [x] Tests: N/A (configuration change only)
  - [x] API: N/A (no endpoint changes)
  - [x] Migrations: N/A (no schema changes)
  - [x] Dependencies: no known impact to dependent services
  - [x] Security: reviewed against secure coding checklist

  AI disclosure

  Assisted by: Claude Code
