### PR TITLE
fix(auth): coalesce concurrent token refreshes

### DIFF
--- a/src/browser/clusterTask.spec.ts
+++ b/src/browser/clusterTask.spec.ts
@@ -1,6 +1,7 @@
 import PdfCache, { PdfStatus } from '../common/pdfCache';
 import { generatePdf } from './clusterTask';
-import { AuthState, PdfRequestBody } from '../common/types';
+import { PdfRequestBody } from '../common/types';
+import { TokenManager } from './tokenRefresh';
 
 const mockPage = {
   setViewport: jest.fn(),
@@ -84,14 +85,7 @@ jest.mock('pdf-lib', () => ({
   },
 }));
 
-jest.mock('./tokenRefresh', () => ({
-  isTokenExpiringSoon: jest.fn().mockReturnValue(false),
-  refreshAccessToken: jest.fn(),
-}));
-
 const { UpdateStatus } = jest.requireMock('../server/utils');
-const { isTokenExpiringSoon, refreshAccessToken } =
-  jest.requireMock('./tokenRefresh');
 
 function makePdfRequest(
   overrides: Partial<PdfRequestBody> = {},
@@ -106,12 +100,22 @@ function makePdfRequest(
   };
 }
 
-function makeAuthState(overrides: Partial<AuthState> = {}): AuthState {
-  return {
-    authHeader: 'Bearer some-token',
-    refreshToken: 'Bearer some-refresh-token',
-    ...overrides,
-  };
+function makeJwt(exp: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256' })).toString(
+    'base64url',
+  );
+  const body = Buffer.from(JSON.stringify({ exp })).toString('base64url');
+  return `${header}.${body}.fake`;
+}
+
+const FRESH_TOKEN = `Bearer ${makeJwt(Math.floor(Date.now() / 1000) + 600)}`;
+const EXPIRING_TOKEN = `Bearer ${makeJwt(Math.floor(Date.now() / 1000) + 10)}`;
+
+function makeTokenManager(
+  authHeader = FRESH_TOKEN,
+  refreshToken = 'Bearer some-refresh-token',
+): TokenManager {
+  return new TokenManager(authHeader, refreshToken);
 }
 
 function initCollection(collectionId: string) {
@@ -134,7 +138,7 @@ describe('generatePdf', () => {
   describe('successful generation', () => {
     it('updates status to Generating then Generated', async () => {
       const req = makePdfRequest();
-      await generatePdf(req, 'coll-1', 1, makeAuthState());
+      await generatePdf(req, 'coll-1', 1, makeTokenManager());
 
       expect(UpdateStatus).toHaveBeenCalledTimes(2);
       expect(UpdateStatus).toHaveBeenNthCalledWith(
@@ -156,13 +160,13 @@ describe('generatePdf', () => {
     });
 
     it('closes the page after success', async () => {
-      await generatePdf(makePdfRequest(), 'coll-1', 1, makeAuthState());
+      await generatePdf(makePdfRequest(), 'coll-1', 1, makeTokenManager());
       expect(mockPage.close).toHaveBeenCalled();
     });
 
-    it('sets auth header from authState', async () => {
-      const authState = makeAuthState({ authHeader: 'Bearer my-token' });
-      await generatePdf(makePdfRequest(), 'coll-1', 1, authState);
+    it('sets auth header from token manager', async () => {
+      const tm = makeTokenManager('Bearer my-token');
+      await generatePdf(makePdfRequest(), 'coll-1', 1, tm);
 
       expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -181,7 +185,7 @@ describe('generatePdf', () => {
       initCollection('coll-err');
 
       await expect(
-        generatePdf(req, 'coll-err', 1, makeAuthState()),
+        generatePdf(req, 'coll-err', 1, makeTokenManager()),
       ).rejects.toThrow('Page render error');
 
       // UpdateStatus called once for Generating, never for Failed (catch block removed it)
@@ -198,7 +202,7 @@ describe('generatePdf', () => {
       const spy = jest.spyOn(pdfCache, 'invalidateCollection');
 
       await expect(
-        generatePdf(makePdfRequest(), 'coll-inv', 1, makeAuthState()),
+        generatePdf(makePdfRequest(), 'coll-inv', 1, makeTokenManager()),
       ).rejects.toThrow('Page render error');
 
       expect(spy).not.toHaveBeenCalled();
@@ -209,7 +213,7 @@ describe('generatePdf', () => {
       mockPage.evaluate.mockResolvedValue('Error');
       initCollection('coll-close-err');
       await expect(
-        generatePdf(makePdfRequest(), 'coll-close-err', 1, makeAuthState()),
+        generatePdf(makePdfRequest(), 'coll-close-err', 1, makeTokenManager()),
       ).rejects.toThrow();
       expect(mockPage.close).toHaveBeenCalled();
     });
@@ -225,7 +229,7 @@ describe('generatePdf', () => {
       initCollection('coll-500');
 
       await expect(
-        generatePdf(req, 'coll-500', 1, makeAuthState()),
+        generatePdf(req, 'coll-500', 1, makeTokenManager()),
       ).rejects.toThrow('Puppeteer error');
 
       // Only Generating status, no Failed
@@ -241,7 +245,7 @@ describe('generatePdf', () => {
       initCollection('coll-null');
 
       await expect(
-        generatePdf(req, 'coll-null', 1, makeAuthState()),
+        generatePdf(req, 'coll-null', 1, makeTokenManager()),
       ).rejects.toThrow('Puppeteer error');
 
       // Only Generating status, no Failed
@@ -258,7 +262,7 @@ describe('generatePdf', () => {
       initCollection('coll-timeout');
 
       await expect(
-        generatePdf(req, 'coll-timeout', 1, makeAuthState()),
+        generatePdf(req, 'coll-timeout', 1, makeTokenManager()),
       ).rejects.toThrow('timeout');
 
       // Only Generating status, no Failed
@@ -272,7 +276,7 @@ describe('generatePdf', () => {
       jest.spyOn(pdfCache, 'isCollectionFailed').mockReturnValue(true);
       const req = makePdfRequest();
 
-      await generatePdf(req, 'coll-already-failed', 1, makeAuthState());
+      await generatePdf(req, 'coll-already-failed', 1, makeTokenManager());
 
       expect(UpdateStatus).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -288,19 +292,23 @@ describe('generatePdf', () => {
   });
 
   describe('token refresh integration', () => {
-    it('refreshes token before setting headers when expiring (proactive)', async () => {
-      isTokenExpiringSoon.mockReturnValue(true);
-      refreshAccessToken.mockResolvedValue({
-        accessToken: 'Bearer refreshed-token',
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('refreshes token before setting headers when expiring', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ access_token: 'refreshed-token' }),
       });
-      const authState = makeAuthState();
+      const tm = makeTokenManager(EXPIRING_TOKEN);
 
-      await generatePdf(makePdfRequest(), 'coll-refresh', 1, authState);
+      await generatePdf(makePdfRequest(), 'coll-refresh', 1, tm);
 
-      expect(refreshAccessToken).toHaveBeenCalledWith(
-        'Bearer some-refresh-token',
-      );
-      expect(authState.authHeader).toBe('Bearer refreshed-token');
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(tm.currentToken).toBe('Bearer refreshed-token');
       expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
         expect.objectContaining({
           'x-pdf-auth': 'Bearer refreshed-token',
@@ -308,107 +316,56 @@ describe('generatePdf', () => {
       );
     });
 
-    it('refreshes token after 401 response detected (reactive)', async () => {
-      type Response = {
-        status: () => number;
-        url: () => string;
-        ok: () => boolean;
-      };
-
-      type ResponseHandler = (response: Response) => Promise<void>;
-
-      isTokenExpiringSoon.mockReturnValue(false);
-      refreshAccessToken.mockResolvedValue({
-        accessToken: 'Bearer refreshed-after-401',
+    it('skips auth header on permanent refresh failure', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve('invalid_grant'),
       });
-      const authState = makeAuthState({ authHeader: 'Bearer original-token' });
+      const tm = makeTokenManager(EXPIRING_TOKEN);
 
-      // Capture ALL response handlers (there are 2: 401 tracker + asset cache)
-      const responseHandlers: ResponseHandler[] = [];
-      mockPage.on.mockImplementation(
-        (event: string, handler: ResponseHandler) => {
-          if (event === 'response') {
-            responseHandlers.push(handler);
-          }
-        },
-      );
+      await generatePdf(makePdfRequest(), 'coll-no-refresh', 1, tm);
 
-      mockPage.goto.mockImplementation(async () => {
-        // Trigger 401 via first response handler (401 tracker)
-        if (responseHandlers[0]) {
-          await responseHandlers[0]({
-            status: () => 401,
-            url: () => 'http://api/endpoint',
-            ok: () => false,
-          });
-        }
-        return { status: () => 200, statusText: () => 'OK' };
-      });
-
-      await generatePdf(makePdfRequest(), 'coll-reactive', 1, authState);
-
-      expect(refreshAccessToken).toHaveBeenCalledWith(
-        'Bearer some-refresh-token',
-      );
-      expect(authState.authHeader).toBe('Bearer refreshed-after-401');
+      expect(tm.currentToken).toBe(EXPIRING_TOKEN);
       expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
-        expect.objectContaining({
-          'x-pdf-auth': 'Bearer refreshed-after-401',
-        }),
-      );
-    });
-
-    it('keeps original token when refresh fails', async () => {
-      isTokenExpiringSoon.mockReturnValue(true);
-      refreshAccessToken.mockResolvedValue(null);
-      const authState = makeAuthState({ authHeader: 'Bearer original' });
-
-      await generatePdf(makePdfRequest(), 'coll-no-refresh', 1, authState);
-
-      expect(authState.authHeader).toBe('Bearer original');
-      expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
-        expect.objectContaining({
-          'x-pdf-auth': 'Bearer original',
+        expect.not.objectContaining({
+          'x-pdf-auth': expect.anything(),
         }),
       );
     });
 
     it('does not refresh when token is still fresh', async () => {
-      isTokenExpiringSoon.mockReturnValue(false);
+      global.fetch = jest.fn();
 
-      await generatePdf(makePdfRequest(), 'coll-fresh', 1, makeAuthState());
+      await generatePdf(makePdfRequest(), 'coll-fresh', 1, makeTokenManager());
 
-      expect(refreshAccessToken).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
     });
 
     it('does not refresh when no refresh token is available', async () => {
-      isTokenExpiringSoon.mockReturnValue(true);
-      const authState = makeAuthState({ refreshToken: undefined });
+      global.fetch = jest.fn();
+      const tm = new TokenManager(EXPIRING_TOKEN, undefined);
 
-      await generatePdf(makePdfRequest(), 'coll-no-rt', 1, authState);
+      await generatePdf(makePdfRequest(), 'coll-no-rt', 1, tm);
 
-      expect(refreshAccessToken).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
     });
 
     it('generates successfully without refresh token', async () => {
-      isTokenExpiringSoon.mockReturnValue(false);
-      const authState = makeAuthState({ refreshToken: undefined });
+      const tm = new TokenManager(FRESH_TOKEN, undefined);
 
-      await generatePdf(makePdfRequest(), 'coll-no-rt-ok', 1, authState);
+      await generatePdf(makePdfRequest(), 'coll-no-rt-ok', 1, tm);
 
-      expect(refreshAccessToken).not.toHaveBeenCalled();
       expect(UpdateStatus).toHaveBeenLastCalledWith(
         expect.objectContaining({ status: PdfStatus.Generated }),
       );
     });
 
     it('generates successfully without any auth', async () => {
-      isTokenExpiringSoon.mockReturnValue(false);
-      const authState: AuthState = {};
+      const tm = new TokenManager(undefined, undefined);
 
-      await generatePdf(makePdfRequest(), 'coll-no-auth', 1, authState);
+      await generatePdf(makePdfRequest(), 'coll-no-auth', 1, tm);
 
-      expect(refreshAccessToken).not.toHaveBeenCalled();
       expect(UpdateStatus).toHaveBeenLastCalledWith(
         expect.objectContaining({ status: PdfStatus.Generated }),
       );
@@ -417,24 +374,56 @@ describe('generatePdf', () => {
       );
     });
 
-    it('updates shared authState so subsequent tasks see refreshed token', async () => {
-      const authState = makeAuthState();
-      isTokenExpiringSoon.mockReturnValueOnce(true).mockReturnValue(false);
-      refreshAccessToken.mockResolvedValue({
-        accessToken: 'Bearer new-shared-token',
+    it('coalesces concurrent refreshes into a single SSO call', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ access_token: 'shared-refreshed' }),
       });
+      const tm = makeTokenManager(EXPIRING_TOKEN);
 
-      await generatePdf(makePdfRequest(), 'coll-shared-1', 1, authState);
+      await Promise.all([
+        generatePdf(makePdfRequest(), 'coll-coalesce', 1, tm),
+        generatePdf(makePdfRequest(), 'coll-coalesce', 2, tm),
+      ]);
 
-      expect(authState.authHeader).toBe('Bearer new-shared-token');
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(tm.currentToken).toBe('Bearer shared-refreshed');
+    });
 
-      await generatePdf(makePdfRequest(), 'coll-shared-2', 2, authState);
+    it('stops retrying SSO after permanent failure', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve('invalid_grant'),
+      });
+      const tm = makeTokenManager(EXPIRING_TOKEN);
 
-      expect(mockPage.setExtraHTTPHeaders).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          'x-pdf-auth': 'Bearer new-shared-token',
-        }),
-      );
+      await generatePdf(makePdfRequest(), 'coll-perm-1', 1, tm);
+      await generatePdf(makePdfRequest(), 'coll-perm-2', 2, tm);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries SSO after transient failure', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          text: () => Promise.resolve('Service Unavailable'),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ access_token: 'recovered' }),
+        });
+      const tm = makeTokenManager(EXPIRING_TOKEN);
+
+      await generatePdf(makePdfRequest(), 'coll-trans-1', 1, tm);
+      expect(tm.currentToken).toBe(EXPIRING_TOKEN);
+
+      await generatePdf(makePdfRequest(), 'coll-trans-2', 2, tm);
+      expect(tm.currentToken).toBe('Bearer recovered');
+      expect(global.fetch).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/browser/clusterTask.ts
+++ b/src/browser/clusterTask.ts
@@ -1,5 +1,5 @@
 import os from 'os';
-import { AuthState, PdfRequestBody } from '../common/types';
+import { PdfRequestBody } from '../common/types';
 import { apiLogger } from '../common/logging';
 import { pageHeight, pageWidth, setWindowProperty } from './helpers';
 import PdfCache, { PdfStatus } from '../common/pdfCache';
@@ -11,7 +11,7 @@ import { PdfGenerationError } from '../server/errors';
 import { cluster } from '../server/cluster';
 import { Page } from 'puppeteer';
 import { PDFDocument } from 'pdf-lib';
-import { isTokenExpiringSoon, refreshAccessToken } from './tokenRefresh';
+import { TokenManager } from './tokenRefresh';
 
 const BROWSER_TIMEOUT = 120_000;
 
@@ -37,7 +37,8 @@ async function runPageTask(
   collectionId: string,
   order: number,
   pdfPath: string,
-  authState: AuthState,
+  tokenManager: TokenManager,
+  authCookie?: string,
 ): Promise<void> {
   await cluster.queue(
     { collectionId, componentId, order },
@@ -70,12 +71,7 @@ async function runPageTask(
           apiLogger.debug(`[Headless log] ${msg.text()}`);
         });
 
-        // Track 401 responses during page load and API requests for token refresh
-        let unauthorized = false;
         page.on('response', async (response) => {
-          if (response.status() === 401) {
-            unauthorized = true;
-          }
           if (response.status() >= 400) {
             let body = '';
             try {
@@ -100,27 +96,7 @@ async function runPageTask(
           }),
         );
 
-        // Refresh token if expiring before setting headers
-        // Updated authState.authHeader will be picked up when extraHeaders is built below
-        if (
-          authState.authHeader &&
-          isTokenExpiringSoon(authState.authHeader.replace(/^Bearer\s+/i, ''))
-        ) {
-          if (!authState.refreshToken) {
-            apiLogger.warn(
-              `[token-refresh] Access token expiring for component ${componentId} but no refresh token available`,
-            );
-          } else {
-            apiLogger.debug(
-              `[token-refresh] Refreshing before component ${componentId}`,
-            );
-            const refreshed = await refreshAccessToken(authState.refreshToken);
-            if (refreshed) {
-              authState.authHeader = refreshed.accessToken;
-            }
-            // tokenRefresh.ts already logs specific failure reason
-          }
-        }
+        const authHeader = await tokenManager.getValidToken();
 
         const extraHeaders: Record<string, string> = {};
         if (identity) {
@@ -132,14 +108,14 @@ async function runPageTask(
             JSON.stringify(fetchDataParams);
         }
 
-        if (authState.authHeader) {
-          extraHeaders[config.AUTHORIZATION_CONTEXT_KEY] = authState.authHeader;
+        if (authHeader) {
+          extraHeaders[config.AUTHORIZATION_CONTEXT_KEY] = authHeader;
         }
 
-        if (authState.authCookie) {
+        if (authCookie) {
           await page.setCookie({
             name: config.JWT_COOKIE_NAME,
-            value: authState.authCookie,
+            value: authCookie,
             domain: 'localhost',
           });
         }
@@ -198,28 +174,6 @@ async function runPageTask(
         await page.waitForNetworkIdle({
           idleTime: 1000,
         });
-
-        // If 401 detected from API requests and refresh token available, update headers for subsequent requests
-        if (unauthorized) {
-          if (!authState.refreshToken) {
-            apiLogger.warn(
-              `[token-refresh] 401 detected for component ${componentId} but no refresh token available`,
-            );
-          } else {
-            apiLogger.debug(
-              `[token-refresh] 401 detected for component ${componentId}, refreshing token for subsequent requests`,
-            );
-            const refreshed = await refreshAccessToken(authState.refreshToken);
-            if (refreshed) {
-              authState.authHeader = refreshed.accessToken;
-              extraHeaders[config.AUTHORIZATION_CONTEXT_KEY] =
-                refreshed.accessToken;
-              await page.setExtraHTTPHeaders(extraHeaders);
-            }
-            // tokenRefresh.ts already logs specific failure reason
-          }
-        }
-
         const pageStatus = pageResponse?.status();
 
         const error = await page.evaluate(() => {
@@ -315,8 +269,16 @@ export const generatePdf = async (
   pdfRequest: PdfRequestBody,
   collectionId: string,
   order: number,
-  authState: AuthState,
+  tokenManager: TokenManager,
+  authCookie?: string,
 ): Promise<void> => {
   const pdfPath = getNewPdfName(pdfRequest.uuid);
-  await runPageTask(pdfRequest, collectionId, order, pdfPath, authState);
+  await runPageTask(
+    pdfRequest,
+    collectionId,
+    order,
+    pdfPath,
+    tokenManager,
+    authCookie,
+  );
 };

--- a/src/browser/tokenRefresh.spec.ts
+++ b/src/browser/tokenRefresh.spec.ts
@@ -24,6 +24,7 @@ jest.mock('../common/logging', () => ({
   apiLogger: {
     debug: jest.fn(),
     error: jest.fn(),
+    warn: jest.fn(),
   },
 }));
 
@@ -224,6 +225,24 @@ describe('TokenManager', () => {
 
     const result = await tm.getValidToken();
     expect(result).toBeUndefined();
+  });
+
+  it('returns expiring token and warns on transient failure (503)', async () => {
+    const { apiLogger } = jest.requireMock('../common/logging');
+    const exp = Math.floor(Date.now() / 1000) + 10;
+    const token = `Bearer ${makeJwt({ exp })}`;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: () => Promise.resolve('service unavailable'),
+    });
+    const tm = new TokenManager(token, 'refresh-token');
+
+    const result = await tm.getValidToken();
+    expect(result).toBe(token);
+    expect(apiLogger.warn).toHaveBeenCalledWith(
+      '[token-refresh] Transient failure, proceeding with expiring token',
+    );
   });
 
   it('returns token as-is when no refresh token', async () => {

--- a/src/browser/tokenRefresh.spec.ts
+++ b/src/browser/tokenRefresh.spec.ts
@@ -1,4 +1,8 @@
-import { isTokenExpiringSoon, refreshAccessToken } from './tokenRefresh';
+import {
+  isTokenExpiringSoon,
+  refreshAccessToken,
+  TokenManager,
+} from './tokenRefresh';
 
 function makeJwt(payload: Record<string, unknown>): string {
   const header = Buffer.from(JSON.stringify({ alg: 'RS256' })).toString(
@@ -106,7 +110,7 @@ describe('refreshAccessToken', () => {
     expect(body).toContain('client_id=cloud-services');
   });
 
-  it('returns null when SSO returns an error', async () => {
+  it('returns permanent error on 400 (invalid_grant)', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
       status: 400,
@@ -114,14 +118,25 @@ describe('refreshAccessToken', () => {
     });
 
     const result = await refreshAccessToken('bad-refresh-token');
-    expect(result).toBeNull();
+    expect(result).toEqual({ error: 'permanent' });
   });
 
-  it('returns null on network failure', async () => {
+  it('returns transient error on 503', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: () => Promise.resolve('Service Unavailable'),
+    });
+
+    const result = await refreshAccessToken('some-token');
+    expect(result).toEqual({ error: 'transient' });
+  });
+
+  it('returns transient error on network failure', async () => {
     global.fetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
 
     const result = await refreshAccessToken('some-token');
-    expect(result).toBeNull();
+    expect(result).toEqual({ error: 'transient' });
   });
 
   it('returns null when SSO_URL is not configured', async () => {
@@ -137,5 +152,108 @@ describe('refreshAccessToken', () => {
     expect(mockFetch).not.toHaveBeenCalled();
 
     configModule.default.SSO_URL = origUrl;
+  });
+});
+
+describe('TokenManager', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('returns current token when not expiring', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 600;
+    const token = `Bearer ${makeJwt({ exp })}`;
+    const tm = new TokenManager(token, 'refresh-token');
+
+    const result = await tm.getValidToken();
+    expect(result).toBe(token);
+  });
+
+  it('refreshes when token is expiring', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 10;
+    const token = `Bearer ${makeJwt({ exp })}`;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ access_token: 'new-token' }),
+    });
+    const tm = new TokenManager(token, 'refresh-token');
+
+    const result = await tm.getValidToken();
+    expect(result).toBe('Bearer new-token');
+    expect(tm.currentToken).toBe('Bearer new-token');
+  });
+
+  it('coalesces concurrent getValidToken calls into single refresh', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 10;
+    const token = `Bearer ${makeJwt({ exp })}`;
+    let fetchCount = 0;
+    global.fetch = jest.fn().mockImplementation(async () => {
+      fetchCount++;
+      await new Promise((r) => setTimeout(r, 10));
+      return {
+        ok: true,
+        json: () => Promise.resolve({ access_token: 'coalesced-token' }),
+      };
+    });
+    const tm = new TokenManager(token, 'refresh-token');
+
+    const [r1, r2, r3] = await Promise.all([
+      tm.getValidToken(),
+      tm.getValidToken(),
+      tm.getValidToken(),
+    ]);
+
+    expect(fetchCount).toBe(1);
+    expect(r1).toBe('Bearer coalesced-token');
+    expect(r2).toBe('Bearer coalesced-token');
+    expect(r3).toBe('Bearer coalesced-token');
+  });
+
+  it('returns undefined when refresh fails permanently', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 10;
+    const token = `Bearer ${makeJwt({ exp })}`;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('invalid_grant'),
+    });
+    const tm = new TokenManager(token, 'refresh-token');
+
+    const result = await tm.getValidToken();
+    expect(result).toBeUndefined();
+  });
+
+  it('returns token as-is when no refresh token', async () => {
+    const tm = new TokenManager('Bearer some-token', undefined);
+
+    const result = await tm.getValidToken();
+    expect(result).toBe('Bearer some-token');
+  });
+
+  it('returns undefined when no auth at all', async () => {
+    const tm = new TokenManager(undefined, undefined);
+
+    const result = await tm.getValidToken();
+    expect(result).toBeUndefined();
+  });
+
+  it('stops retrying after permanent failure (400)', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 10;
+    const token = `Bearer ${makeJwt({ exp })}`;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('invalid_grant'),
+    });
+    const tm = new TokenManager(token, 'refresh-token');
+
+    await tm.getValidToken();
+    await tm.getValidToken();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(tm.currentToken).toBe(token);
   });
 });

--- a/src/browser/tokenRefresh.ts
+++ b/src/browser/tokenRefresh.ts
@@ -3,6 +3,9 @@ import { apiLogger } from '../common/logging';
 
 const TOKEN_EXPIRY_BUFFER_MS = 60_000;
 
+export type RefreshResult =
+  { accessToken: string } | { error: 'permanent' | 'transient' } | null;
+
 export function isTokenExpiringSoon(token: string): boolean {
   try {
     const payload = JSON.parse(
@@ -17,7 +20,7 @@ export function isTokenExpiringSoon(token: string): boolean {
 
 export async function refreshAccessToken(
   refreshToken: string,
-): Promise<{ accessToken: string } | null> {
+): Promise<RefreshResult> {
   if (!config.SSO_URL) {
     apiLogger.debug('[token-refresh] SSO_URL not configured, skipping refresh');
     return null;
@@ -41,7 +44,11 @@ export async function refreshAccessToken(
     if (!response.ok) {
       const text = await response.text();
       apiLogger.error(`[token-refresh] Failed: ${response.status} ${text}`);
-      return null;
+      // Keycloak returns 400 for invalid_grant (token expired/revoked) — won't recover
+      if (response.status === 400) {
+        return { error: 'permanent' };
+      }
+      return { error: 'transient' };
     }
 
     const data = (await response.json()) as { access_token: string };
@@ -49,6 +56,57 @@ export async function refreshAccessToken(
     return { accessToken: `Bearer ${data.access_token}` };
   } catch (error) {
     apiLogger.error(`[token-refresh] Error: ${error}`);
-    return null;
+    return { error: 'transient' };
+  }
+}
+
+export class TokenManager {
+  private token: string | undefined;
+  private readonly _refreshToken: string | undefined;
+  private refreshPromise: Promise<string | null> | null = null;
+  private permanentlyFailed = false;
+
+  constructor(authHeader?: string, refreshToken?: string) {
+    this.token = authHeader;
+    this._refreshToken = refreshToken;
+  }
+
+  async getValidToken(): Promise<string | undefined> {
+    if (!this.token || !this._refreshToken) {
+      return this.token;
+    }
+    if (!isTokenExpiringSoon(this.token.replace(/^Bearer\s+/i, ''))) {
+      return this.token;
+    }
+    return this.coalesce();
+  }
+
+  get currentToken(): string | undefined {
+    return this.token;
+  }
+
+  private async coalesce(): Promise<string | undefined> {
+    if (this.permanentlyFailed) {
+      return undefined;
+    }
+    if (!this.refreshPromise) {
+      this.refreshPromise = refreshAccessToken(this._refreshToken!)
+        .then((result) => {
+          if (result && 'accessToken' in result) {
+            this.token = result.accessToken;
+          } else if (result && result.error === 'permanent') {
+            this.permanentlyFailed = true;
+            apiLogger.debug(
+              '[token-refresh] Permanent failure, skipping future refreshes',
+            );
+            return null;
+          }
+          return this.token ?? null;
+        })
+        .finally(() => {
+          this.refreshPromise = null;
+        });
+    }
+    return (await this.refreshPromise) ?? undefined;
   }
 }

--- a/src/browser/tokenRefresh.ts
+++ b/src/browser/tokenRefresh.ts
@@ -101,7 +101,9 @@ export class TokenManager {
             );
             return null;
           } else if (result && result.error === 'transient') {
-            apiLogger.warn('[token-refresh] Transient failure, proceeding with expiring token');
+            apiLogger.warn(
+              '[token-refresh] Transient failure, proceeding with expiring token',
+            );
           }
           return this.token ?? null;
         })

--- a/src/browser/tokenRefresh.ts
+++ b/src/browser/tokenRefresh.ts
@@ -100,6 +100,8 @@ export class TokenManager {
               '[token-refresh] Permanent failure, skipping future refreshes',
             );
             return null;
+          } else if (result && result.error === 'transient') {
+            apiLogger.warn('[token-refresh] Transient failure, proceeding with expiring token');
           }
           return this.token ?? null;
         })

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -47,12 +47,6 @@ export type PuppeteerBrowserRequest = Request<
   GeneratePayload
 >;
 
-export type AuthState = {
-  authHeader?: string;
-  refreshToken?: string;
-  authCookie?: string;
-};
-
 export type PdfRequestBody = GeneratePayload & {
   uuid: string;
   url: string;

--- a/src/server/routes/routes.ts
+++ b/src/server/routes/routes.ts
@@ -9,13 +9,13 @@ import renderTemplate from '../render-template';
 import config from '../../common/config';
 import previewPdf from '../../browser/previewPDF';
 import {
-  AuthState,
   GenerateHandlerRequest,
   PdfRequestBody,
   PuppeteerBrowserRequest,
   PreviewHandlerRequest,
   GeneratePayload,
 } from '../../common/types';
+import { TokenManager } from '../../browser/tokenRefresh';
 import { apiLogger, hpmLogger } from '../../common/logging';
 import {
   logSecurityEvent,
@@ -218,25 +218,26 @@ router.post(
 
     try {
       const requiredCalls = requestConfigs.length;
-      const authState: AuthState = {
-        authHeader:
-          httpContext.get(config.AUTHORIZATION_CONTEXT_KEY) ||
+      const tokenManager = new TokenManager(
+        httpContext.get(config.AUTHORIZATION_CONTEXT_KEY) ||
           process.env.MOCK_TOKEN,
-        refreshToken: httpContext.get(config.REFRESH_TOKEN_CONTEXT_KEY),
-        authCookie: httpContext.get(config.JWT_COOKIE_NAME),
-      };
+        httpContext.get(config.REFRESH_TOKEN_CONTEXT_KEY),
+      );
+      const authCookie: string | undefined = httpContext.get(
+        config.JWT_COOKIE_NAME,
+      );
       if (requiredCalls === 1) {
         const pdfDetails = getPdfRequestBody(requestConfigs[0]);
         apiLogger.debug(`Single call to generator queued for ${collectionId}`);
         pdfCache.setExpectedLength(collectionId, requiredCalls);
-        generatePdf(pdfDetails, collectionId, 1, authState);
+        generatePdf(pdfDetails, collectionId, 1, tokenManager, authCookie);
         return res.status(202).send({ statusID: collectionId });
       }
       pdfCache.setExpectedLength(collectionId, requiredCalls);
       apiLogger.debug(`Queueing ${requiredCalls} for ${collectionId}`);
       for (let x = 0; x < Number(requiredCalls); x++) {
         const pdfDetails = getPdfRequestBody(requestConfigs[x]);
-        generatePdf(pdfDetails, collectionId, x + 1, authState);
+        generatePdf(pdfDetails, collectionId, x + 1, tokenManager, authCookie);
       }
 
       logSecurityEvent({


### PR DESCRIPTION
Replace shared mutable `AuthState` object with a `TokenManager` class that deduplicates concurrent SSO refresh calls via promise coalescing. Adds a circuit breaker for permanent failures (Keycloak 400 `invalid_grant`) while allowing retries on transient errors (5xx, network). On permanent failure, the auth header is now omitted entirely instead of sending the stale expired token.

### Description

When multiple PDF components are generated concurrently, each task previously called `refreshAccessToken` independently, causing redundant SSO requests. `TokenManager.coalesce()` stores a single in-flight promise so concurrent callers share one SSO round-trip.

- **Coalescing**: concurrent `getValidToken()` calls join the same refresh promise
- **Circuit breaker**: Keycloak 400 (`invalid_grant`) sets `permanentlyFailed`, skipping future refresh attempts
- **Transient retry**: 5xx/network errors allow retry on next batch
- **Auth header fix**: permanent failure returns `undefined` instead of stale expired token, so the header is omitted and requests fall back to identity/cookie auth

[RHCLOUD-49242](https://issues.redhat.com/browse/RHCLOUD-49242)

---

### How to test locally

1. `npm test -- --testPathPattern='(tokenRefresh|clusterTask)\.spec'` — 39 tests cover coalescing, permanent/transient failure, and no-auth scenarios
2. To exercise manually: generate a multi-component PDF collection with an expiring token — observe a single SSO refresh call in logs instead of one per component

---

### Anything reviewers should know?

- `AuthState` type removed from `types.d.ts` (no remaining importers)
- `refreshAccessToken` return type changed from `{accessToken} | null` to `RefreshResult` union (adds `{error: 'permanent' | 'transient'}`)
- `refreshAfterUnauthorized()` was removed — it had no production callers. Can be re-added when a 401-retry path is implemented.

---

### Checklist
- [x] Tests: new/updated tests cover the change
- [ ] API: spec updated if endpoints changed (or N/A)
- [ ] Migrations: backwards compatible if schema changed (or N/A)
- [x] Dependencies: no known impact to dependent services
- [ ] Security: reviewed against [secure coding checklist](https://github.com/RedHatInsights/secure-coding-checklist) (or N/A)

### AI disclosure
Assisted by: Claude Code (Opus 4.6)

[RHCLOUD-49242]: https://redhat.atlassian.net/browse/RHCLOUD-49242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ