### PR TITLE
chore(deps): upgrade chrome to 149.0.7827.103

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf install -y python3 make gcc-c++ git && dnf clean all
 RUN PUPPETEER_SKIP_DOWNLOAD=true npm ci
 
 # Download Chrome 149.0.7827.53 for PDF generation (patches CVEs in bundled 149.0.7827.22)
-RUN npx @puppeteer/browsers install chrome@149.0.7827.53 --path /opt/app-root/src/.cache/puppeteer
+RUN npx @puppeteer/browsers install chrome@149.0.7827.103 --path /opt/app-root/src/.cache/puppeteer
 
 # Check for circular dependencies
 RUN node circular.js


### PR DESCRIPTION
## Summary

- Upgrades Chrome from 149.0.7827.53 to 149.0.7827.103 to patch additional CVEs found in grype scan.

---
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)