### PR TITLE
fix(docker): migrate to hardened/hummingbird base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN mkdir -p bin
 
 # Install build tools for native npm modules (node-gyp)
-RUN dnf install -y python3 make gcc-c++ git && dnf clean all
+RUN dnf install -y python3 make gcc-c++ git unzip && dnf clean all
 
 # Install npm dependencies from lockfile (skip default Chrome download)
 RUN PUPPETEER_SKIP_DOWNLOAD=true npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN dnf install -y python3 make gcc-c++ git unzip && dnf clean all
 # Install npm dependencies from lockfile (skip default Chrome download)
 RUN PUPPETEER_SKIP_DOWNLOAD=true npm ci
 
-# Download Chrome 149.0.7827.103 for PDF generation (patches CVEs in bundled 149.0.7827.22)
-RUN npx @puppeteer/browsers install chrome@149.0.7827.103 --path /opt/app-root/src/.cache/puppeteer
+# Download Chrome 150.0.7871.181 for PDF generation (patches CVEs in bundled 149.0.7827.22)
+RUN npx @puppeteer/browsers install chrome@150.0.7871.181 --path /opt/app-root/src/.cache/puppeteer
 
 # Check for circular dependencies
 RUN node circular.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Stage 1: Build
-FROM registry.access.redhat.com/ubi9/nodejs-22:9.8-1780375952@sha256:fa57578b663265db4360118e6aedb7f150b8162b81ef567e0a66b14b80ee3329 AS builder
+# Stage 1: Build the application
+FROM registry.access.redhat.com/hi/nodejs:22-builder AS builder
 
 USER 0
 WORKDIR /pdf-gen
@@ -12,7 +12,7 @@ RUN dnf install -y python3 make gcc-c++ git && dnf clean all
 # Install npm dependencies from lockfile (skip default Chrome download)
 RUN PUPPETEER_SKIP_DOWNLOAD=true npm ci
 
-# Download Chrome 149.0.7827.53 for PDF generation (patches CVEs in bundled 149.0.7827.22)
+# Download Chrome 149.0.7827.103 for PDF generation (patches CVEs in bundled 149.0.7827.22)
 RUN npx @puppeteer/browsers install chrome@149.0.7827.103 --path /opt/app-root/src/.cache/puppeteer
 
 # Check for circular dependencies
@@ -21,30 +21,58 @@ RUN node circular.js
 # Build the application
 ENV NODE_ENV=production
 RUN npm run build
+RUN npm prune --omit=dev
 
-# Stage 2: Runtime
-FROM registry.access.redhat.com/ubi9/nodejs-22-minimal:9.8-1779828907@sha256:75a2c4753c2475d715e31304ec1effef61770713e6e9fdafdcb80351dbdf3ba5
+# Stage 2: Collect Chrome runtime dependencies
+# UBI9 base is used here because the hardened builder image lacks the full
+# set of X11/GTK repos needed for Chrome dependencies. This stage is
+# intermediate and discarded after build.
+FROM registry.access.redhat.com/ubi9/ubi:latest AS chrome-deps
 
-USER 0
-WORKDIR /pdf-gen
+# Snapshot installed packages before adding Chrome deps
+RUN rpm -qa --queryformat '%{NAME}\n' | sort > /pkgs-before.txt
 
 # Install Chrome runtime dependencies
-RUN microdnf install -y bzip2 fontconfig pango \
+RUN dnf install -y bzip2 fontconfig pango \
   libXcomposite libXcursor libXdamage \
   libXext libXi libXtst cups-libs \
   libXScrnSaver libXrandr alsa-lib \
   atk gtk3 libdrm libgbm libxshmfence \
-  nss && microdnf clean all
+  nss && dnf clean all
+
+# Collect only files from newly installed packages into /chrome-rootfs
+# This avoids copying unrelated packages to the runtime image.
+# Directories are created (not copied) to prevent recursive copies of
+# shared system directories like /usr/lib64.
+RUN rpm -qa --queryformat '%{NAME}\n' | sort > /pkgs-after.txt && \
+    comm -13 /pkgs-before.txt /pkgs-after.txt > /new-pkgs.txt && \
+    mkdir -p /chrome-rootfs && \
+    cat /new-pkgs.txt | xargs rpm -ql 2>/dev/null | while IFS= read -r f; do \
+      if [ -d "$f" ] && [ ! -L "$f" ]; then \
+        mkdir -p "/chrome-rootfs$f"; \
+      elif [ -e "$f" ] || [ -L "$f" ]; then \
+        mkdir -p "/chrome-rootfs$(dirname "$f")" && \
+        cp -a "$f" "/chrome-rootfs$f" 2>/dev/null || true; \
+      fi; \
+    done
+
+# Stage 3: Runtime (hardened distroless image)
+FROM registry.access.redhat.com/hi/nodejs:22
+
+WORKDIR /pdf-gen
+
+# Copy Chrome runtime dependencies (libs, fonts, configs) from chrome-deps stage
+COPY --from=chrome-deps /chrome-rootfs/ /
 
 # Copy application artifacts from builder
-COPY --from=builder /pdf-gen/dist ./dist
-COPY --from=builder /pdf-gen/node_modules ./node_modules
-COPY --from=builder /pdf-gen/package.json ./package.json
-COPY --from=builder /pdf-gen/public ./public
-COPY --from=builder /pdf-gen/docs/openapi.json ./docs/openapi.json
+COPY --chown=1001:0 --from=builder /pdf-gen/dist ./dist
+COPY --chown=1001:0 --from=builder /pdf-gen/node_modules ./node_modules
+COPY --chown=1001:0 --from=builder /pdf-gen/package.json ./package.json
+COPY --chown=1001:0 --from=builder /pdf-gen/public ./public
+COPY --chown=1001:0 --from=builder /pdf-gen/docs/openapi.json ./docs/openapi.json
 
 # Copy Chrome binary
-COPY --from=builder /opt/app-root/src/.cache/puppeteer /opt/app-root/src/.cache/puppeteer
+COPY --chown=1001:0 --from=builder /opt/app-root/src/.cache/puppeteer /opt/app-root/src/.cache/puppeteer
 
 ENV HOME=/opt/app-root/src
 ENV XDG_CONFIG_HOME="/tmp/.chromium"

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,15 @@ RUN rpm -qa --queryformat '%{NAME}\n' | sort > /pkgs-after.txt && \
         mkdir -p "/chrome-rootfs$(dirname "$f")" && \
         cp -a "$f" "/chrome-rootfs$f" 2>/dev/null || true; \
       fi; \
-    done
+    done && \
+    # Merge /usr/sbin into /usr/bin for hummingbird image compatibility.
+    # Hummingbird images symlink /usr/sbin → /usr/bin; Docker COPY cannot
+    # write into symlink targets, so consolidate before the final COPY.
+    if [ -d /chrome-rootfs/usr/sbin ]; then \
+      mkdir -p /chrome-rootfs/usr/bin && \
+      cp -a /chrome-rootfs/usr/sbin/. /chrome-rootfs/usr/bin/ 2>/dev/null || true && \
+      rm -rf /chrome-rootfs/usr/sbin; \
+    fi
 
 # Stage 3: Runtime (hardened distroless image)
 FROM registry.access.redhat.com/hi/nodejs:22

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the application
-FROM registry.access.redhat.com/hi/nodejs:22-builder AS builder
+FROM registry.access.redhat.com/hi/nodejs:22-builder@sha256:8899348361f9a222b2eb51bff6a6b328e8de58910a861161b007781ea57905ce AS builder
 
 USER 0
 WORKDIR /pdf-gen
@@ -27,7 +27,7 @@ RUN npm prune --omit=dev
 # UBI9 base is used here because the hardened builder image lacks the full
 # set of X11/GTK repos needed for Chrome dependencies. This stage is
 # intermediate and discarded after build.
-FROM registry.access.redhat.com/ubi9/ubi:latest AS chrome-deps
+FROM registry.access.redhat.com/ubi9/ubi:latest@sha256:2a6bd6971e6026177b2439655282660519198870e9063c4a03a208de88be2e9e AS chrome-deps
 
 # Snapshot installed packages before adding Chrome deps
 RUN rpm -qa --queryformat '%{NAME}\n' | sort > /pkgs-before.txt
@@ -65,7 +65,7 @@ RUN rpm -qa --queryformat '%{NAME}\n' | sort > /pkgs-after.txt && \
     fi
 
 # Stage 3: Runtime (hardened distroless image)
-FROM registry.access.redhat.com/hi/nodejs:22
+FROM registry.access.redhat.com/hi/nodejs:22@sha256:cf26fa86a695e51b233a899a11e8b62bbe7ffb97bdaaaed3977cfc404d4be7a9
 
 WORKDIR /pdf-gen
 


### PR DESCRIPTION
Migrates the pdf-generator Dockerfile from UBI9 to Red Hat hardened/hummingbird base images, eliminating Go stdlib/crypto/net CVEs that were embedded in UBI9 system binaries.

Jira: RHCLOUD-49460
Epic: RHCLOUD-49468

---

## Changes

- **Builder**: `ubi9/nodejs-22` → `hi/nodejs:22-builder` (hardened)
- **Runtime**: `ubi9/nodejs-22-minimal` → `hi/nodejs:22` (distroless)
- **chrome-deps** intermediate stage: throwaway UBI9 stage that installs Chrome runtime libraries (X11, GTK3, NSS, etc.) via RPM diff and copies only the delta files into the distroless runtime — UBI9 does not appear in the final image
- All three `FROM` images pinned with sha256 digests for Konflux reproducibility

## Why a separate chrome-deps stage?

The hummingbird runtime image is distroless (no shell, no package manager). Chrome requires ~15 system libraries that cannot be `dnf install`-ed at runtime. The intermediate UBI9 stage snapshots the RPM database before/after installing those libraries, collects only the newly added files, and copies them into `/chrome-rootfs` for the final `COPY --from=chrome-deps /chrome-rootfs/ /`.

## Testing

- Unit tests pass (97/97)
- Konflux pipeline validation pending on this PR