### PR TITLE
feat(browser): explicit PDF render readiness contract

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -142,4 +142,4 @@ parameters:
   value: "false"
 - description: Milliseconds to wait for v1 readiness contract marker after domcontentloaded
   name: PDF_READINESS_CAPABILITY_DETECTION_MS
-  value: "500"
+  value: "2000"

--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -66,6 +66,12 @@ objects:
           value: ${SSO_URL}
         - name: SSO_CLIENT_ID
           value: ${SSO_CLIENT_ID}
+        - name: PDF_READINESS_ENABLED
+          value: ${PDF_READINESS_ENABLED}
+        - name: PDF_READINESS_FALLBACK_NETWORK_IDLE
+          value: ${PDF_READINESS_FALLBACK_NETWORK_IDLE}
+        - name: PDF_READINESS_CAPABILITY_DETECTION_MS
+          value: ${PDF_READINESS_CAPABILITY_DETECTION_MS}
         resources:
           limits:
             cpu: ${CPU_LIMIT_SERVICE}
@@ -128,3 +134,12 @@ parameters:
 - description: SSO client ID for token refresh
   name: SSO_CLIENT_ID
   value: "cloud-services"
+- description: Enable explicit PDF readiness contract (set to false to restore networkidle2)
+  name: PDF_READINESS_ENABLED
+  value: "true"
+- description: Allow networkidle fallback for legacy pages without v1 readiness contract
+  name: PDF_READINESS_FALLBACK_NETWORK_IDLE
+  value: "false"
+- description: Milliseconds to wait for v1 readiness contract marker after domcontentloaded
+  name: PDF_READINESS_CAPABILITY_DETECTION_MS
+  value: "500"

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -23,6 +23,22 @@ For further details please read the in-depth [PDF Template development](./pdf-te
 
 If you have an old template from the `v1` implementation, they are stored in an [older git reference and can be found here](https://github.com/RedHatInsights/pdf-generator/tree/636695be494f145f89f11264e6b7707f8077a443/src/templates).
 
+### Explicit render readiness (optional)
+
+Templates that fetch data in multiple batches with gaps longer than ~1s between requests can cause
+the default network-idle wait to resolve too early. Opt into the explicit readiness contract:
+
+1. Set `renderReadiness: 'explicit-v1'` on each create-payload entry.
+2. Call `onPdfReady` (passed as a prop to your module, or via `usePdfReady()` from the generator bootstrap) after your template's async work is finished.
+3. Bootstrap still waits for fonts, images, and two animation frames before setting `data-pdf-ready="true"`.
+
+**Capability detection:** after `domcontentloaded`, the generator waits up to
+`PDF_READINESS_CAPABILITY_DETECTION_MS` (default **2000ms**) for
+`#root[data-pdf-readiness-contract="v1"]`. Bootstrap sets that attribute as soon as the client
+bundle evaluates. If your federated bundle loads slower than the detection window, generation
+falls through without waiting for `data-pdf-ready` (network-idle fallback only when
+`PDF_READINESS_FALLBACK_NETWORK_IDLE=true`). Raise the ClowdApp param if needed.
+
 ### Test your setup locally
 
 Follow the [Local development setup](./local-development-setup.md) guide and ensure your PDF template is working. You should replace 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -348,6 +348,11 @@
             "type": "boolean",
             "default": false,
             "description": "is your pdf read like a novel or a powerpoint?"
+          },
+          "renderReadiness": {
+            "type": "string",
+            "enum": ["explicit-v1"],
+            "description": "Opt into the explicit PDF readiness contract. When set, the template must call onPdfReady after async work finishes; the generator waits for data-pdf-ready instead of network idle."
           }
         },
         "example": {
@@ -361,7 +366,8 @@
           "additionalData": {
             "customerStatus": "active"
           },
-          "landscape": true
+          "landscape": true,
+          "renderReadiness": "explicit-v1"
         }
       },
       "PdfDetails": {

--- a/docs/pdf-template-development.md
+++ b/docs/pdf-template-development.md
@@ -279,3 +279,53 @@ const PDFTemplate = ({ asyncData, additionalData }) => {
 export default PDFTemplate;
 
 ```
+## Explicit render readiness
+
+If your template performs multi-batch fetches with long gaps between requests, opt into the
+explicit readiness contract so generation does not finish on a premature network-idle signal.
+
+### Create payload
+
+```js
+{
+  manifestLocation: "/apps/landing/fed-mods.json",
+  scope: "landing",
+  module: "./PdfEntry",
+  renderReadiness: "explicit-v1",
+  fetchDataParams: { /* ... */ },
+}
+```
+
+### Signal ready from the template
+
+Call `onPdfReady` after your async work (including any in-template follow-up fetches) is done:
+
+```tsx
+const PDFTemplate = ({ asyncData, onPdfReady }) => {
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      // ... finish rendering / secondary fetches ...
+      if (!cancelled) {
+        onPdfReady?.();
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [asyncData, onPdfReady]);
+
+  return <div>{/* ... */}</div>;
+};
+```
+
+After `onPdfReady`, the generator bootstrap still waits for fonts, images, and two `requestAnimationFrame`
+ticks before setting `data-pdf-ready="true"`.
+
+### Capability detection window
+
+The service looks for `#root[data-pdf-readiness-contract="v1"]` for up to
+`PDF_READINESS_CAPABILITY_DETECTION_MS` (default 2000ms) after `domcontentloaded`. That attribute is
+set when the client bootstrap bundle evaluates. If the federated JS bundle takes longer than the
+detection window to load, readiness falls through (network-idle fallback only when
+`PDF_READINESS_FALLBACK_NETWORK_IDLE=true`). Tune the ClowdApp parameter if your assets are slow.

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,4 +14,5 @@ module.exports = {
   },
   transformIgnorePatterns: ['node_modules/(?!(pdf-merger-js)/)'],
   testMatch: ['./**/*.spec.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '\\.e2e\\.spec\\.ts$'],
 };

--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -1,0 +1,17 @@
+const { defaults: tsjPreset } = require('ts-jest/presets');
+
+module.exports = {
+  displayName: 'e2e',
+  preset: 'ts-jest/presets/js-with-ts',
+  testTimeout: 60000,
+  testMatch: ['**/*.e2e.spec.ts'],
+  testPathIgnorePatterns: ['/node_modules/'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(puppeteer|puppeteer-core|@puppeteer/browsers|chromium-bidi|pdf-merger-js)/)',
+  ],
+  transform: {
+    ...tsjPreset.transform,
+  },
+  setupFiles: ['<rootDir>/jest.setup.ts'],
+  maxWorkers: 1,
+};

--- a/package.json
+++ b/package.json
@@ -101,6 +101,9 @@
     "serve": "npx wait-on dist/server.js && nodemon dist/server.js",
     "start:server": "NODE_ENV=development npx concurrently \"npx webpack -c ./config/webpack.config.js -w\" \"npm run serve\"",
     "test": "jest --config jest.config.js",
+    "browser:install": "puppeteer browsers install chrome",
+    "test:e2e": "jest --config jest.e2e.config.js --runInBand",
+    "test:all": "npm test && npm run test:e2e",
     "api:validate": "npx vacuum lint  -d ./docs/openapi.json"
   },
   "watch": {

--- a/src/browser/clusterTask.spec.ts
+++ b/src/browser/clusterTask.spec.ts
@@ -1,6 +1,7 @@
 import PdfCache, { PdfStatus } from '../common/pdfCache';
 import { generatePdf } from './clusterTask';
-import { AuthState, PdfRequestBody } from '../common/types';
+import { PdfRequestBody } from '../common/types';
+import { TokenManager } from './tokenRefresh';
 
 const mockPage = {
   setViewport: jest.fn(),
@@ -19,8 +20,11 @@ const mockPage = {
 
 jest.mock('../server/cluster', () => ({
   cluster: {
-    queue: jest.fn((taskFn: ({ page }: { page: unknown }) => Promise<void>) =>
-      taskFn({ page: mockPage }),
+    queue: jest.fn(
+      (
+        _taskData: unknown,
+        taskFn: ({ page }: { page: unknown }) => Promise<void>,
+      ) => taskFn({ page: mockPage }),
     ),
   },
 }));
@@ -44,6 +48,7 @@ jest.mock('../common/logging', () => ({
     debug: jest.fn(),
     info: jest.fn(),
     error: jest.fn(),
+    warn: jest.fn(),
     warning: jest.fn(),
   },
 }));
@@ -80,14 +85,7 @@ jest.mock('pdf-lib', () => ({
   },
 }));
 
-jest.mock('./tokenRefresh', () => ({
-  isTokenExpiringSoon: jest.fn().mockReturnValue(false),
-  refreshAccessToken: jest.fn(),
-}));
-
 const { UpdateStatus } = jest.requireMock('../server/utils');
-const { isTokenExpiringSoon, refreshAccessToken } =
-  jest.requireMock('./tokenRefresh');
 
 function makePdfRequest(
   overrides: Partial<PdfRequestBody> = {},
@@ -102,12 +100,22 @@ function makePdfRequest(
   };
 }
 
-function makeAuthState(overrides: Partial<AuthState> = {}): AuthState {
-  return {
-    authHeader: 'Bearer some-token',
-    refreshToken: 'Bearer some-refresh-token',
-    ...overrides,
-  };
+function makeJwt(exp: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'RS256' })).toString(
+    'base64url',
+  );
+  const body = Buffer.from(JSON.stringify({ exp })).toString('base64url');
+  return `${header}.${body}.fake`;
+}
+
+const FRESH_TOKEN = `Bearer ${makeJwt(Math.floor(Date.now() / 1000) + 600)}`;
+const EXPIRING_TOKEN = `Bearer ${makeJwt(Math.floor(Date.now() / 1000) + 10)}`;
+
+function makeTokenManager(
+  authHeader = FRESH_TOKEN,
+  refreshToken = 'Bearer some-refresh-token',
+): TokenManager {
+  return new TokenManager(authHeader, refreshToken);
 }
 
 function initCollection(collectionId: string) {
@@ -130,7 +138,7 @@ describe('generatePdf', () => {
   describe('successful generation', () => {
     it('updates status to Generating then Generated', async () => {
       const req = makePdfRequest();
-      await generatePdf(req, 'coll-1', 1, makeAuthState());
+      await generatePdf(req, 'coll-1', 1, makeTokenManager());
 
       expect(UpdateStatus).toHaveBeenCalledTimes(2);
       expect(UpdateStatus).toHaveBeenNthCalledWith(
@@ -152,13 +160,13 @@ describe('generatePdf', () => {
     });
 
     it('closes the page after success', async () => {
-      await generatePdf(makePdfRequest(), 'coll-1', 1, makeAuthState());
+      await generatePdf(makePdfRequest(), 'coll-1', 1, makeTokenManager());
       expect(mockPage.close).toHaveBeenCalled();
     });
 
-    it('sets auth header from authState', async () => {
-      const authState = makeAuthState({ authHeader: 'Bearer my-token' });
-      await generatePdf(makePdfRequest(), 'coll-1', 1, authState);
+    it('sets auth header from token manager', async () => {
+      const tm = makeTokenManager('Bearer my-token');
+      await generatePdf(makePdfRequest(), 'coll-1', 1, tm);
 
       expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -169,47 +177,50 @@ describe('generatePdf', () => {
   });
 
   describe('page render error', () => {
-    it('updates status to Failed when DOM error element exists', async () => {
+    it('throws error without calling UpdateStatus(Failed) - retry not defeated', async () => {
       mockPage.evaluate.mockResolvedValue(
         'Request failed with status code 401',
       );
       const req = makePdfRequest();
       initCollection('coll-err');
 
-      await generatePdf(req, 'coll-err', 1, makeAuthState());
+      await expect(
+        generatePdf(req, 'coll-err', 1, makeTokenManager()),
+      ).rejects.toThrow('Page render error');
 
-      expect(UpdateStatus).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          status: PdfStatus.Failed,
-          componentId: req.uuid,
-          collectionId: 'coll-err',
-          error: expect.stringContaining('Page render error'),
-        }),
+      // UpdateStatus called once for Generating, never for Failed (catch block removed it)
+      expect(UpdateStatus).toHaveBeenCalledTimes(1);
+      expect(UpdateStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ status: PdfStatus.Generating }),
       );
     });
 
-    it('invalidates the collection on render error', async () => {
+    it('throws error without invalidating collection (retry handled by cluster)', async () => {
       mockPage.evaluate.mockResolvedValue('Some error');
       initCollection('coll-inv');
       const pdfCache = PdfCache.getInstance();
       const spy = jest.spyOn(pdfCache, 'invalidateCollection');
 
-      await generatePdf(makePdfRequest(), 'coll-inv', 1, makeAuthState());
+      await expect(
+        generatePdf(makePdfRequest(), 'coll-inv', 1, makeTokenManager()),
+      ).rejects.toThrow('Page render error');
 
-      expect(spy).toHaveBeenCalledWith('coll-inv', expect.any(String));
+      expect(spy).not.toHaveBeenCalled();
       spy.mockRestore();
     });
 
     it('closes the page after render error', async () => {
       mockPage.evaluate.mockResolvedValue('Error');
       initCollection('coll-close-err');
-      await generatePdf(makePdfRequest(), 'coll-close-err', 1, makeAuthState());
+      await expect(
+        generatePdf(makePdfRequest(), 'coll-close-err', 1, makeTokenManager()),
+      ).rejects.toThrow();
       expect(mockPage.close).toHaveBeenCalled();
     });
   });
 
   describe('page load failure', () => {
-    it('updates status to Failed on 500 response', async () => {
+    it('throws error without calling UpdateStatus(Failed) on 500 response', async () => {
       mockPage.goto.mockResolvedValue({
         status: () => 500,
         statusText: () => 'Internal Server Error',
@@ -217,48 +228,45 @@ describe('generatePdf', () => {
       const req = makePdfRequest();
       initCollection('coll-500');
 
-      await generatePdf(req, 'coll-500', 1, makeAuthState());
+      await expect(
+        generatePdf(req, 'coll-500', 1, makeTokenManager()),
+      ).rejects.toThrow('Puppeteer error');
 
-      expect(UpdateStatus).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          status: PdfStatus.Failed,
-          componentId: req.uuid,
-          error: expect.stringContaining('Puppeteer error'),
-        }),
+      // Only Generating status, no Failed
+      expect(UpdateStatus).toHaveBeenCalledTimes(1);
+      expect(UpdateStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ status: PdfStatus.Generating }),
       );
     });
 
-    it('updates status to Failed on null response', async () => {
+    it('throws error without calling UpdateStatus(Failed) on null response', async () => {
       mockPage.goto.mockResolvedValue(null);
       const req = makePdfRequest();
       initCollection('coll-null');
 
-      await generatePdf(req, 'coll-null', 1, makeAuthState());
+      await expect(
+        generatePdf(req, 'coll-null', 1, makeTokenManager()),
+      ).rejects.toThrow('Puppeteer error');
 
-      expect(UpdateStatus).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          status: PdfStatus.Failed,
-        }),
-      );
+      // Only Generating status, no Failed
+      expect(UpdateStatus).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('timeout failure', () => {
-    it('updates status to Failed on page.goto timeout', async () => {
+    it('throws error without calling UpdateStatus(Failed) on page.goto timeout', async () => {
       mockPage.goto.mockRejectedValue(
         new Error('TimeoutError: Navigation timeout of 120000ms exceeded'),
       );
       const req = makePdfRequest();
       initCollection('coll-timeout');
 
-      await generatePdf(req, 'coll-timeout', 1, makeAuthState());
+      await expect(
+        generatePdf(req, 'coll-timeout', 1, makeTokenManager()),
+      ).rejects.toThrow('timeout');
 
-      expect(UpdateStatus).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          status: PdfStatus.Failed,
-          error: expect.stringContaining('timeout'),
-        }),
-      );
+      // Only Generating status, no Failed
+      expect(UpdateStatus).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -268,7 +276,7 @@ describe('generatePdf', () => {
       jest.spyOn(pdfCache, 'isCollectionFailed').mockReturnValue(true);
       const req = makePdfRequest();
 
-      await generatePdf(req, 'coll-already-failed', 1, makeAuthState());
+      await generatePdf(req, 'coll-already-failed', 1, makeTokenManager());
 
       expect(UpdateStatus).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -284,19 +292,23 @@ describe('generatePdf', () => {
   });
 
   describe('token refresh integration', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
     it('refreshes token before setting headers when expiring', async () => {
-      isTokenExpiringSoon.mockReturnValue(true);
-      refreshAccessToken.mockResolvedValue({
-        accessToken: 'Bearer refreshed-token',
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ access_token: 'refreshed-token' }),
       });
-      const authState = makeAuthState();
+      const tm = makeTokenManager(EXPIRING_TOKEN);
 
-      await generatePdf(makePdfRequest(), 'coll-refresh', 1, authState);
+      await generatePdf(makePdfRequest(), 'coll-refresh', 1, tm);
 
-      expect(refreshAccessToken).toHaveBeenCalledWith(
-        'Bearer some-refresh-token',
-      );
-      expect(authState.authHeader).toBe('Bearer refreshed-token');
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(tm.currentToken).toBe('Bearer refreshed-token');
       expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
         expect.objectContaining({
           'x-pdf-auth': 'Bearer refreshed-token',
@@ -304,57 +316,56 @@ describe('generatePdf', () => {
       );
     });
 
-    it('keeps original token when refresh fails', async () => {
-      isTokenExpiringSoon.mockReturnValue(true);
-      refreshAccessToken.mockResolvedValue(null);
-      const authState = makeAuthState({ authHeader: 'Bearer original' });
+    it('skips auth header on permanent refresh failure', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve('invalid_grant'),
+      });
+      const tm = makeTokenManager(EXPIRING_TOKEN);
 
-      await generatePdf(makePdfRequest(), 'coll-no-refresh', 1, authState);
+      await generatePdf(makePdfRequest(), 'coll-no-refresh', 1, tm);
 
-      expect(authState.authHeader).toBe('Bearer original');
+      expect(tm.currentToken).toBe(EXPIRING_TOKEN);
       expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
-        expect.objectContaining({
-          'x-pdf-auth': 'Bearer original',
+        expect.not.objectContaining({
+          'x-pdf-auth': expect.anything(),
         }),
       );
     });
 
     it('does not refresh when token is still fresh', async () => {
-      isTokenExpiringSoon.mockReturnValue(false);
+      global.fetch = jest.fn();
 
-      await generatePdf(makePdfRequest(), 'coll-fresh', 1, makeAuthState());
+      await generatePdf(makePdfRequest(), 'coll-fresh', 1, makeTokenManager());
 
-      expect(refreshAccessToken).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
     });
 
     it('does not refresh when no refresh token is available', async () => {
-      isTokenExpiringSoon.mockReturnValue(true);
-      const authState = makeAuthState({ refreshToken: undefined });
+      global.fetch = jest.fn();
+      const tm = new TokenManager(EXPIRING_TOKEN, undefined);
 
-      await generatePdf(makePdfRequest(), 'coll-no-rt', 1, authState);
+      await generatePdf(makePdfRequest(), 'coll-no-rt', 1, tm);
 
-      expect(refreshAccessToken).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
     });
 
     it('generates successfully without refresh token', async () => {
-      isTokenExpiringSoon.mockReturnValue(false);
-      const authState = makeAuthState({ refreshToken: undefined });
+      const tm = new TokenManager(FRESH_TOKEN, undefined);
 
-      await generatePdf(makePdfRequest(), 'coll-no-rt-ok', 1, authState);
+      await generatePdf(makePdfRequest(), 'coll-no-rt-ok', 1, tm);
 
-      expect(refreshAccessToken).not.toHaveBeenCalled();
       expect(UpdateStatus).toHaveBeenLastCalledWith(
         expect.objectContaining({ status: PdfStatus.Generated }),
       );
     });
 
     it('generates successfully without any auth', async () => {
-      isTokenExpiringSoon.mockReturnValue(false);
-      const authState: AuthState = {};
+      const tm = new TokenManager(undefined, undefined);
 
-      await generatePdf(makePdfRequest(), 'coll-no-auth', 1, authState);
+      await generatePdf(makePdfRequest(), 'coll-no-auth', 1, tm);
 
-      expect(refreshAccessToken).not.toHaveBeenCalled();
       expect(UpdateStatus).toHaveBeenLastCalledWith(
         expect.objectContaining({ status: PdfStatus.Generated }),
       );
@@ -363,24 +374,56 @@ describe('generatePdf', () => {
       );
     });
 
-    it('updates shared authState so subsequent tasks see refreshed token', async () => {
-      const authState = makeAuthState();
-      isTokenExpiringSoon.mockReturnValueOnce(true).mockReturnValue(false);
-      refreshAccessToken.mockResolvedValue({
-        accessToken: 'Bearer new-shared-token',
+    it('coalesces concurrent refreshes into a single SSO call', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ access_token: 'shared-refreshed' }),
       });
+      const tm = makeTokenManager(EXPIRING_TOKEN);
 
-      await generatePdf(makePdfRequest(), 'coll-shared-1', 1, authState);
+      await Promise.all([
+        generatePdf(makePdfRequest(), 'coll-coalesce', 1, tm),
+        generatePdf(makePdfRequest(), 'coll-coalesce', 2, tm),
+      ]);
 
-      expect(authState.authHeader).toBe('Bearer new-shared-token');
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(tm.currentToken).toBe('Bearer shared-refreshed');
+    });
 
-      await generatePdf(makePdfRequest(), 'coll-shared-2', 2, authState);
+    it('stops retrying SSO after permanent failure', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        text: () => Promise.resolve('invalid_grant'),
+      });
+      const tm = makeTokenManager(EXPIRING_TOKEN);
 
-      expect(mockPage.setExtraHTTPHeaders).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          'x-pdf-auth': 'Bearer new-shared-token',
-        }),
-      );
+      await generatePdf(makePdfRequest(), 'coll-perm-1', 1, tm);
+      await generatePdf(makePdfRequest(), 'coll-perm-2', 2, tm);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries SSO after transient failure', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          text: () => Promise.resolve('Service Unavailable'),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ access_token: 'recovered' }),
+        });
+      const tm = makeTokenManager(EXPIRING_TOKEN);
+
+      await generatePdf(makePdfRequest(), 'coll-trans-1', 1, tm);
+      expect(tm.currentToken).toBe(EXPIRING_TOKEN);
+
+      await generatePdf(makePdfRequest(), 'coll-trans-2', 2, tm);
+      expect(tm.currentToken).toBe('Bearer recovered');
+      expect(global.fetch).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/browser/clusterTask.ts
+++ b/src/browser/clusterTask.ts
@@ -1,5 +1,5 @@
 import os from 'os';
-import { AuthState, PdfRequestBody } from '../common/types';
+import { PdfRequestBody } from '../common/types';
 import { apiLogger } from '../common/logging';
 import { pageHeight, pageWidth, setWindowProperty } from './helpers';
 import PdfCache, { PdfStatus } from '../common/pdfCache';
@@ -12,7 +12,7 @@ import { cluster } from '../server/cluster';
 import { navigateAndWaitForPdfReady } from './navigateAndWaitForPdfReady';
 import { Page } from 'puppeteer';
 import { PDFDocument } from 'pdf-lib';
-import { isTokenExpiringSoon, refreshAccessToken } from './tokenRefresh';
+import { TokenManager } from './tokenRefresh';
 
 const BROWSER_TIMEOUT = 120_000;
 
@@ -38,249 +38,244 @@ async function runPageTask(
   collectionId: string,
   order: number,
   pdfPath: string,
-  authState: AuthState,
+  tokenManager: TokenManager,
+  authCookie?: string,
 ): Promise<void> {
-  await cluster.queue(async ({ page }: { page: Page }) => {
-    if (PdfCache.getInstance().isCollectionFailed(collectionId)) {
-      apiLogger.debug(
-        `Skipping component ${componentId}: collection ${collectionId} already failed`,
-      );
-      await UpdateStatus({
-        collectionId,
-        status: PdfStatus.Failed,
-        filepath: '',
-        componentId,
-        order,
-        error: 'Collection failed before this component started',
-      });
-      return;
-    }
-
-    try {
-      await UpdateStatus({
-        status: PdfStatus.Generating,
-        filepath: '',
-        order,
-        componentId,
-        collectionId,
-      });
-      await page.setViewport({ width: pageWidth, height: pageHeight });
-      page.on('console', (msg) =>
-        apiLogger.info(`[Headless log] ${msg.text()}`),
-      );
-
-      page.on('response', async (response) => {
-        if (response.status() >= 400) {
-          let body = '';
-          try {
-            body = await response.text();
-          } catch {
-            body = '<unreadable>';
-          }
-          apiLogger.debug(
-            `[Headless response] ${response.status()} ${response.url()} | body=${body}`,
-          );
-        }
-      });
-
-      await setWindowProperty(
-        page,
-        'customPuppeteerParams',
-        JSON.stringify({
-          puppeteerParams: {
-            pageWidth,
-            pageHeight,
-          },
-        }),
-      );
-
-      // Refresh token if expiring before setting headers
-      if (
-        authState.refreshToken &&
-        authState.authHeader &&
-        isTokenExpiringSoon(authState.authHeader.replace(/^Bearer\s+/i, ''))
-      ) {
-        apiLogger.debug(
-          `[token-refresh] Refreshing before component ${componentId}`,
-        );
-        const refreshed = await refreshAccessToken(authState.refreshToken);
-        if (refreshed) {
-          authState.authHeader = refreshed.accessToken;
-        }
-      }
-
-      const extraHeaders: Record<string, string> = {};
-      if (identity) {
-        extraHeaders['x-rh-identity'] = identity;
-      }
-
-      if (fetchDataParams) {
-        extraHeaders[config?.OPTIONS_HEADER_NAME] =
-          JSON.stringify(fetchDataParams);
-      }
-
-      if (authState.authHeader) {
-        extraHeaders[config.AUTHORIZATION_CONTEXT_KEY] = authState.authHeader;
-      }
-
-      if (authState.authCookie) {
-        await page.setCookie({
-          name: config.JWT_COOKIE_NAME,
-          value: authState.authCookie,
-          domain: 'localhost',
-        });
-      }
-
-      await page.setRequestInterception(true);
-      page.on('request', async (interceptedRequest) => {
-        const reqUrl = interceptedRequest.url();
-        if (
-          interceptedRequest.method() === 'GET' &&
-          reqUrl.includes('/apps/') &&
-          /\.(js|css)(\?|$)/.test(reqUrl)
-        ) {
-          const cached = assetCache.get(assetCacheKey(reqUrl));
-          if (cached) {
-            await interceptedRequest.respond({
-              status: 200,
-              contentType: cached.contentType,
-              body: cached.body,
-            });
-            return;
-          }
-        }
-        await interceptedRequest.continue();
-      });
-
-      page.on('response', async (resp) => {
-        const respUrl = resp.url();
-        if (
-          resp.ok() &&
-          respUrl.includes('/apps/') &&
-          /\.(js|css)(\?|$)/.test(respUrl) &&
-          !assetCache.has(assetCacheKey(respUrl))
-        ) {
-          try {
-            const body = await resp.buffer();
-            assetCache.set(assetCacheKey(respUrl), {
-              body,
-              contentType:
-                resp.headers()['content-type'] ||
-                (respUrl.match(/\.css(\?|$)/)
-                  ? 'text/css'
-                  : 'application/javascript'),
-            });
-          } catch {
-            // response body may not be available
-          }
-        }
-      });
-
-      await page.setExtraHTTPHeaders(extraHeaders);
-
-      const pageResponse = await navigateAndWaitForPdfReady(page, url, {
-        timeout: BROWSER_TIMEOUT,
-      });
-      const pageStatus = pageResponse?.status();
-
-      const error = await page.evaluate(() => {
-        const appError = document.getElementById('crc-pdf-generator-err');
-        if (appError) {
-          return appError.innerText;
-        }
-        const templateError = document.getElementById('report-error');
-        if (templateError) {
-          return templateError.innerText;
-        }
-      });
-
-      if (error && error.length > 0) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let response: any;
-        try {
-          response = JSON.parse(error);
-          apiLogger.debug(response.data);
-        } catch {
-          response = error;
-          apiLogger.debug(`Page render error ${response}`);
-        }
-        throw new PdfGenerationError(
-          collectionId,
-          componentId,
-          `Page render error: ${response}`,
-        );
-      }
-      if (!pageStatus || !isValidPageResponse(pageStatus)) {
-        apiLogger.debug(`Page status: ${pageResponse?.statusText()}`);
-        throw new PdfGenerationError(
-          collectionId,
-          componentId,
-          `Puppeteer error while loading the react app: ${pageResponse?.statusText()}`,
-        );
-      }
-
+  await cluster.queue(
+    { collectionId, componentId, order },
+    async ({ page }: { page: Page }) => {
       if (PdfCache.getInstance().isCollectionFailed(collectionId)) {
         apiLogger.debug(
-          `Aborting component ${componentId}: collection ${collectionId} failed during page load`,
+          `Skipping component ${componentId}: collection ${collectionId} already failed`,
         );
+        await UpdateStatus({
+          collectionId,
+          status: PdfStatus.Failed,
+          filepath: '',
+          componentId,
+          order,
+          error: 'Collection failed before this component started',
+        });
         return;
       }
 
-      const { headerTemplate, footerTemplate } = getHeaderAndFooterTemplates();
+      try {
+        await UpdateStatus({
+          status: PdfStatus.Generating,
+          filepath: '',
+          order,
+          componentId,
+          collectionId,
+        });
+        await page.setViewport({ width: pageWidth, height: pageHeight });
+        page.on('console', (msg) =>
+          apiLogger.info(`[Headless log] ${msg.text()}`),
+        );
 
-      const buffer = await page.pdf({
-        path: pdfPath,
-        format: 'a4',
-        printBackground: true,
-        margin: {
-          top: '54px',
-          bottom: '54px',
-        },
-        landscape,
-        displayHeaderFooter: true,
-        headerTemplate,
-        footerTemplate,
-        timeout: BROWSER_TIMEOUT,
-      });
-      await store.uploadPDF(componentId, pdfPath).catch((error: unknown) => {
-        apiLogger.error(`Failed to upload PDF: ${error}`);
-      });
-      const pdfDoc = await PDFDocument.load(buffer);
-      const numPages = pdfDoc.getPages().length;
-      apiLogger.debug(`Generated PDF with ${numPages} pages`);
-      await UpdateStatus({
-        collectionId,
-        status: PdfStatus.Generated,
-        filepath: pdfPath,
-        componentId,
-        numPages,
-        order,
-      });
-    } catch (taskError: unknown) {
-      const message =
-        taskError instanceof Error ? taskError.message : String(taskError);
-      apiLogger.error(`Component ${componentId} failed: ${message}`);
-      await UpdateStatus({
-        collectionId,
-        status: PdfStatus.Failed,
-        filepath: '',
-        componentId,
-        order,
-        error: message,
-      });
-      PdfCache.getInstance().invalidateCollection(collectionId, message);
-    } finally {
-      await page.close().catch(() => {});
-    }
-  });
+        page.on('response', async (response) => {
+          if (response.status() >= 400) {
+            let body = '';
+            try {
+              body = await response.text();
+            } catch {
+              body = '<unreadable>';
+            }
+            apiLogger.debug(
+              `[Headless response] ${response.status()} ${response.url()} | body=${body}`,
+            );
+          }
+        });
+
+        await setWindowProperty(
+          page,
+          'customPuppeteerParams',
+          JSON.stringify({
+            puppeteerParams: {
+              pageWidth,
+              pageHeight,
+            },
+          }),
+        );
+
+        const authHeader = await tokenManager.getValidToken();
+
+        const extraHeaders: Record<string, string> = {};
+        if (identity) {
+          extraHeaders['x-rh-identity'] = identity;
+        }
+
+        if (fetchDataParams) {
+          extraHeaders[config?.OPTIONS_HEADER_NAME] =
+            JSON.stringify(fetchDataParams);
+        }
+
+        if (authHeader) {
+          extraHeaders[config.AUTHORIZATION_CONTEXT_KEY] = authHeader;
+        }
+
+        if (authCookie) {
+          await page.setCookie({
+            name: config.JWT_COOKIE_NAME,
+            value: authCookie,
+            domain: 'localhost',
+          });
+        }
+
+        await page.setRequestInterception(true);
+        page.on('request', async (interceptedRequest) => {
+          const reqUrl = interceptedRequest.url();
+          if (
+            interceptedRequest.method() === 'GET' &&
+            reqUrl.includes('/apps/') &&
+            /\.(js|css)(\?|$)/.test(reqUrl)
+          ) {
+            const cached = assetCache.get(assetCacheKey(reqUrl));
+            if (cached) {
+              await interceptedRequest.respond({
+                status: 200,
+                contentType: cached.contentType,
+                body: cached.body,
+              });
+              return;
+            }
+          }
+          await interceptedRequest.continue();
+        });
+
+        page.on('response', async (resp) => {
+          const respUrl = resp.url();
+          if (
+            resp.ok() &&
+            respUrl.includes('/apps/') &&
+            /\.(js|css)(\?|$)/.test(respUrl) &&
+            !assetCache.has(assetCacheKey(respUrl))
+          ) {
+            try {
+              const body = await resp.buffer();
+              assetCache.set(assetCacheKey(respUrl), {
+                body,
+                contentType:
+                  resp.headers()['content-type'] ||
+                  (respUrl.match(/\.css(\?|$)/)
+                    ? 'text/css'
+                    : 'application/javascript'),
+              });
+            } catch {
+              // response body may not be available
+            }
+          }
+        });
+
+        await page.setExtraHTTPHeaders(extraHeaders);
+
+        const pageResponse = await navigateAndWaitForPdfReady(page, url, {
+          timeout: BROWSER_TIMEOUT,
+        });
+        const pageStatus = pageResponse?.status();
+
+        const error = await page.evaluate(() => {
+          const appError = document.getElementById('crc-pdf-generator-err');
+          if (appError) {
+            return appError.innerText;
+          }
+          const templateError = document.getElementById('report-error');
+          if (templateError) {
+            return templateError.innerText;
+          }
+        });
+
+        if (error && error.length > 0) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          let response: any;
+          try {
+            response = JSON.parse(error);
+            apiLogger.debug(response.data);
+          } catch {
+            response = error;
+            apiLogger.debug(`Page render error ${response}`);
+          }
+          throw new PdfGenerationError(
+            collectionId,
+            componentId,
+            `Page render error: ${response}`,
+          );
+        }
+        if (!pageStatus || !isValidPageResponse(pageStatus)) {
+          apiLogger.debug(`Page status: ${pageResponse?.statusText()}`);
+          throw new PdfGenerationError(
+            collectionId,
+            componentId,
+            `Puppeteer error while loading the react app: ${pageResponse?.statusText()}`,
+          );
+        }
+
+        if (PdfCache.getInstance().isCollectionFailed(collectionId)) {
+          apiLogger.debug(
+            `Aborting component ${componentId}: collection ${collectionId} failed during page load`,
+          );
+          return;
+        }
+
+        const { headerTemplate, footerTemplate } =
+          getHeaderAndFooterTemplates();
+
+        const buffer = await page.pdf({
+          path: pdfPath,
+          format: 'a4',
+          printBackground: true,
+          margin: {
+            top: '54px',
+            bottom: '54px',
+          },
+          landscape,
+          displayHeaderFooter: true,
+          headerTemplate,
+          footerTemplate,
+          timeout: BROWSER_TIMEOUT,
+        });
+        await store.uploadPDF(componentId, pdfPath).catch((error: unknown) => {
+          apiLogger.error(`Failed to upload PDF: ${error}`);
+        });
+        const pdfDoc = await PDFDocument.load(buffer);
+        const numPages = pdfDoc.getPages().length;
+        apiLogger.debug(`Generated PDF with ${numPages} pages`);
+        await UpdateStatus({
+          collectionId,
+          status: PdfStatus.Generated,
+          filepath: pdfPath,
+          componentId,
+          numPages,
+          order,
+        });
+      } catch (taskError: unknown) {
+        const message =
+          taskError instanceof Error ? taskError.message : String(taskError);
+        apiLogger.error(`Component ${componentId} failed: ${message}`);
+        // Do not UpdateStatus(Failed) here - it triggers verifyCollection → invalidateCollection
+        // which sets collection.status = Failed before cluster retries run.
+        // The taskerror handler in cluster.ts records the failure after retries exhausted.
+        throw taskError;
+      } finally {
+        await page.close().catch(() => {});
+      }
+    },
+  );
 }
 
 export const generatePdf = async (
   pdfRequest: PdfRequestBody,
   collectionId: string,
   order: number,
-  authState: AuthState,
+  tokenManager: TokenManager,
+  authCookie?: string,
 ): Promise<void> => {
   const pdfPath = getNewPdfName(pdfRequest.uuid);
-  await runPageTask(pdfRequest, collectionId, order, pdfPath, authState);
+  await runPageTask(
+    pdfRequest,
+    collectionId,
+    order,
+    pdfPath,
+    tokenManager,
+    authCookie,
+  );
 };

--- a/src/browser/clusterTask.ts
+++ b/src/browser/clusterTask.ts
@@ -9,6 +9,7 @@ import { store } from '../common/store';
 import { UpdateStatus, isValidPageResponse } from '../server/utils';
 import { PdfGenerationError } from '../server/errors';
 import { cluster } from '../server/cluster';
+import { navigateAndWaitForPdfReady } from './navigateAndWaitForPdfReady';
 import { Page } from 'puppeteer';
 import { PDFDocument } from 'pdf-lib';
 import { isTokenExpiringSoon, refreshAccessToken } from './tokenRefresh';
@@ -177,12 +178,8 @@ async function runPageTask(
 
       await page.setExtraHTTPHeaders(extraHeaders);
 
-      const pageResponse = await page.goto(url, {
-        waitUntil: 'networkidle2',
+      const pageResponse = await navigateAndWaitForPdfReady(page, url, {
         timeout: BROWSER_TIMEOUT,
-      });
-      await page.waitForNetworkIdle({
-        idleTime: 1000,
       });
       const pageStatus = pageResponse?.status();
 

--- a/src/browser/fixtures/readiness-harness/error.html
+++ b/src/browser/fixtures/readiness-harness/error.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8" /><title>PDF Error Harness</title></head>
+<body>
+  <div id="root" data-pdf-readiness-contract="v1" data-pdf-ready="false"></div>
+  <div id="crc-pdf-generator-err">Test error from component</div>
+</body>
+</html>

--- a/src/browser/fixtures/readiness-harness/hang.html
+++ b/src/browser/fixtures/readiness-harness/hang.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8" /><title>PDF Hang Harness</title></head>
+<body>
+  <div id="root" data-pdf-readiness-contract="v1" data-pdf-ready="false"></div>
+  <script>
+    // v1 contract present but data-pdf-ready never set to true
+  </script>
+</body>
+</html>

--- a/src/browser/fixtures/readiness-harness/index.html
+++ b/src/browser/fixtures/readiness-harness/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>PDF Readiness Harness</title>
+</head>
+<body>
+  <div id="root" data-pdf-readiness-contract="v1" data-pdf-ready="false"></div>
+  <script>
+    (async function () {
+      var root = document.getElementById('root');
+      var SILENT_GAP_MS = 2500;
+
+      // Batch 1: fetch data, render content
+      var batch1 = await fetch('/api/batch/1').then(function (r) { return r.json(); });
+      root.innerHTML = batch1.items.map(function (item) {
+        return '<div class="batch-1">' + item + '</div>';
+      }).join('');
+
+      // Silent gap — no network requests for 2500ms
+      await new Promise(function (resolve) { setTimeout(resolve, SILENT_GAP_MS); });
+
+      // Batch 2: fetch data, render content with marker
+      var batch2 = await fetch('/api/batch/2').then(function (r) { return r.json(); });
+      root.innerHTML += batch2.items.map(function (item) {
+        return '<div class="batch-2">BATCH-2-MARKER: ' + item + '</div>';
+      }).join('');
+
+      // Consumer onPdfReady callback
+      window.__callbackTimestamp = Date.now();
+
+      // Font readiness gate
+      await document.fonts.ready;
+      window.__fontTimestamp = Date.now();
+
+      // Image readiness gate — load a 1x1 pixel PNG served by the test server
+      var img = document.createElement('img');
+      img.src = '/fixtures/test.png';
+      root.appendChild(img);
+      await new Promise(function (resolve) {
+        if (img.complete) { resolve(); return; }
+        img.onload = resolve;
+        img.onerror = resolve;
+      });
+
+      // Two rAF ticks
+      await new Promise(function (resolve) {
+        requestAnimationFrame(function () {
+          requestAnimationFrame(resolve);
+        });
+      });
+
+      // Set readiness
+      root.setAttribute('data-pdf-ready', 'true');
+      window.__readyTimestamp = Date.now();
+    })();
+  </script>
+</body>
+</html>

--- a/src/browser/fixtures/readiness-harness/server.ts
+++ b/src/browser/fixtures/readiness-harness/server.ts
@@ -1,0 +1,63 @@
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+
+const FIXTURE_DIR = path.resolve(__dirname);
+
+// 1x1 transparent PNG
+const PIXEL_PNG = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQAB' +
+    'Nl7BcQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+function serveFile(
+  res: http.ServerResponse,
+  filename: string,
+  contentType: string,
+) {
+  const content = fs.readFileSync(path.join(FIXTURE_DIR, filename), 'utf-8');
+  res.writeHead(200, { 'Content-Type': contentType });
+  res.end(content);
+}
+
+function json(res: http.ServerResponse, data: unknown) {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data));
+}
+
+const ROUTES: Record<string, (res: http.ServerResponse) => void> = {
+  '/': (res) => serveFile(res, 'index.html', 'text/html'),
+  '/error': (res) => serveFile(res, 'error.html', 'text/html'),
+  '/template-error': (res) =>
+    serveFile(res, 'template-error.html', 'text/html'),
+  '/hang': (res) => serveFile(res, 'hang.html', 'text/html'),
+  '/api/batch/1': (res) => json(res, { items: ['item1', 'item2'] }),
+  '/api/batch/2': (res) => json(res, { items: ['batch2-data'] }),
+  '/fixtures/test.png': (res) => {
+    res.writeHead(200, { 'Content-Type': 'image/png' });
+    res.end(PIXEL_PNG);
+  },
+};
+
+export function startFixtureServer(): Promise<{
+  server: http.Server;
+  baseUrl: string;
+}> {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const handler = ROUTES[req.url ?? ''];
+      if (handler) {
+        handler(res);
+      } else {
+        res.writeHead(404);
+        res.end('Not found');
+      }
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr !== null ? addr.port : 0;
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+    });
+  });
+}

--- a/src/browser/fixtures/readiness-harness/template-error.html
+++ b/src/browser/fixtures/readiness-harness/template-error.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8" /><title>PDF Template Error Harness</title></head>
+<body>
+  <div id="root" data-pdf-readiness-contract="v1" data-pdf-ready="false"></div>
+  <div id="report-error">Template rendering failed</div>
+</body>
+</html>

--- a/src/browser/navigateAndWaitForPdfReady.e2e.spec.ts
+++ b/src/browser/navigateAndWaitForPdfReady.e2e.spec.ts
@@ -1,0 +1,72 @@
+import puppeteer, { Browser, Page } from 'puppeteer';
+import http from 'http';
+import { navigateAndWaitForPdfReady } from './navigateAndWaitForPdfReady';
+import { startFixtureServer } from './fixtures/readiness-harness/server';
+
+describe('navigateAndWaitForPdfReady (browser integration)', () => {
+  let browser: Browser;
+  let page: Page;
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    browser = await puppeteer.launch({
+      headless: process.env.PDF_E2E_HEADLESS !== 'false',
+      args: ['--no-sandbox', '--disable-gpu'],
+    });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+  });
+
+  beforeEach(async () => {
+    const fixture = await startFixtureServer();
+    server = fixture.server;
+    baseUrl = fixture.baseUrl;
+    page = await browser.newPage();
+    await page.setCacheEnabled(false);
+    page.on('console', (msg) => {
+      process.stdout.write(`[headless] ${msg.text()}\n`);
+    });
+  });
+
+  afterEach(async () => {
+    await page?.close().catch(() => {});
+    if (typeof server.closeAllConnections === 'function') {
+      server.closeAllConnections();
+    }
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  });
+
+  it('waits through 2500ms silent gap for batch 2', async () => {
+    await navigateAndWaitForPdfReady(page, `${baseUrl}/`);
+
+    const ready = await page.$eval('#root', (el) =>
+      el.getAttribute('data-pdf-ready'),
+    );
+    const text = await page.$eval('#root', (el) => el.textContent);
+
+    expect(ready).toBe('true');
+    expect(text).toContain('BATCH-2-MARKER');
+  });
+
+  it('waits for fonts and images after consumer commit before ready', async () => {
+    await navigateAndWaitForPdfReady(page, `${baseUrl}/`);
+
+    const readyAt = await page.evaluate(
+      () => (window as unknown as Record<string, number>).__readyTimestamp,
+    );
+    const callbackAt = await page.evaluate(
+      () => (window as unknown as Record<string, number>).__callbackTimestamp,
+    );
+    const fontLoadedAt = await page.evaluate(
+      () => (window as unknown as Record<string, number>).__fontTimestamp,
+    );
+
+    expect(callbackAt).toBeLessThanOrEqual(fontLoadedAt);
+    expect(readyAt).toBeGreaterThanOrEqual(fontLoadedAt);
+  });
+});

--- a/src/browser/navigateAndWaitForPdfReady.errors.e2e.spec.ts
+++ b/src/browser/navigateAndWaitForPdfReady.errors.e2e.spec.ts
@@ -1,0 +1,52 @@
+import puppeteer, { Browser, Page } from 'puppeteer';
+import http from 'http';
+import { navigateAndWaitForPdfReady } from './navigateAndWaitForPdfReady';
+import { startFixtureServer } from './fixtures/readiness-harness/server';
+
+describe('navigateAndWaitForPdfReady error handling (browser integration)', () => {
+  let browser: Browser;
+  let page: Page;
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    browser = await puppeteer.launch({
+      headless: process.env.PDF_E2E_HEADLESS !== 'false',
+      args: ['--no-sandbox', '--disable-gpu'],
+    });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+  });
+
+  beforeEach(async () => {
+    const fixture = await startFixtureServer();
+    server = fixture.server;
+    baseUrl = fixture.baseUrl;
+    page = await browser.newPage();
+    await page.setCacheEnabled(false);
+  });
+
+  afterEach(async () => {
+    await page?.close().catch(() => {});
+    if (typeof server.closeAllConnections === 'function') {
+      server.closeAllConnections();
+    }
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  });
+
+  it('throws on #crc-pdf-generator-err', async () => {
+    await expect(
+      navigateAndWaitForPdfReady(page, `${baseUrl}/error`),
+    ).rejects.toThrow(/Page render error/);
+  });
+
+  it('throws on #report-error (SSR template error)', async () => {
+    await expect(
+      navigateAndWaitForPdfReady(page, `${baseUrl}/template-error`),
+    ).rejects.toThrow(/Page render error/);
+  });
+});

--- a/src/browser/navigateAndWaitForPdfReady.timeout.e2e.spec.ts
+++ b/src/browser/navigateAndWaitForPdfReady.timeout.e2e.spec.ts
@@ -1,0 +1,46 @@
+import puppeteer, { Browser, Page } from 'puppeteer';
+import http from 'http';
+import { navigateAndWaitForPdfReady } from './navigateAndWaitForPdfReady';
+import { startFixtureServer } from './fixtures/readiness-harness/server';
+
+describe('navigateAndWaitForPdfReady timeout (browser integration)', () => {
+  let browser: Browser;
+  let page: Page;
+  let server: http.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    browser = await puppeteer.launch({
+      headless: process.env.PDF_E2E_HEADLESS !== 'false',
+      args: ['--no-sandbox', '--disable-gpu'],
+    });
+  });
+
+  afterAll(async () => {
+    await browser?.close();
+  });
+
+  beforeEach(async () => {
+    const fixture = await startFixtureServer();
+    server = fixture.server;
+    baseUrl = fixture.baseUrl;
+    page = await browser.newPage();
+    await page.setCacheEnabled(false);
+  });
+
+  afterEach(async () => {
+    await page?.close().catch(() => {});
+    if (typeof server.closeAllConnections === 'function') {
+      server.closeAllConnections();
+    }
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  });
+
+  it('times out when v1 contract present but ready never set', async () => {
+    await expect(
+      navigateAndWaitForPdfReady(page, `${baseUrl}/hang`, { timeout: 5000 }),
+    ).rejects.toThrow(/exceeded|timeout/i);
+  });
+});

--- a/src/browser/navigateAndWaitForPdfReady.ts
+++ b/src/browser/navigateAndWaitForPdfReady.ts
@@ -1,0 +1,17 @@
+import { Page, HTTPResponse } from 'puppeteer';
+
+const DEFAULT_TIMEOUT = 120_000;
+
+export async function navigateAndWaitForPdfReady(
+  page: Page,
+  url: string,
+  options?: { timeout?: number },
+): Promise<HTTPResponse | null> {
+  const timeout = options?.timeout ?? DEFAULT_TIMEOUT;
+  const response = await page.goto(url, {
+    waitUntil: 'networkidle2',
+    timeout,
+  });
+  await page.waitForNetworkIdle({ idleTime: 1000 });
+  return response;
+}

--- a/src/browser/navigateAndWaitForPdfReady.ts
+++ b/src/browser/navigateAndWaitForPdfReady.ts
@@ -1,4 +1,6 @@
 import { Page, HTTPResponse } from 'puppeteer';
+import config from '../common/config';
+import { apiLogger } from '../common/logging';
 
 const DEFAULT_TIMEOUT = 120_000;
 
@@ -8,10 +10,64 @@ export async function navigateAndWaitForPdfReady(
   options?: { timeout?: number },
 ): Promise<HTTPResponse | null> {
   const timeout = options?.timeout ?? DEFAULT_TIMEOUT;
+
+  if (!config.pdfReadinessEnabled) {
+    const response = await page.goto(url, {
+      waitUntil: 'networkidle2',
+      timeout,
+    });
+    await page.waitForNetworkIdle({ idleTime: 1000 });
+    return response;
+  }
+
   const response = await page.goto(url, {
-    waitUntil: 'networkidle2',
+    waitUntil: 'domcontentloaded',
     timeout,
   });
-  await page.waitForNetworkIdle({ idleTime: 1000 });
+
+  let contractV1Detected = false;
+  try {
+    await page.waitForSelector('#root[data-pdf-readiness-contract="v1"]', {
+      timeout: config.pdfReadinessCapabilityDetectionMs,
+    });
+    contractV1Detected = true;
+  } catch {
+    // v1 marker not found within detection window
+  }
+
+  if (contractV1Detected) {
+    await page.waitForFunction(
+      () => {
+        const root = document.getElementById('root');
+        if (document.getElementById('crc-pdf-generator-err')) return true;
+        if (document.getElementById('report-error')) return true;
+        return root?.getAttribute('data-pdf-ready') === 'true';
+      },
+      { timeout },
+    );
+
+    const errorState = await page.evaluate(() => {
+      const appError = document.getElementById('crc-pdf-generator-err');
+      if (appError) return appError.innerText;
+      const templateError = document.getElementById('report-error');
+      if (templateError) return templateError.innerText;
+      return null;
+    });
+
+    if (errorState) {
+      throw new Error(`Page render error: ${errorState}`);
+    }
+
+    return response;
+  }
+
+  if (config.pdfReadinessFallbackNetworkIdle) {
+    apiLogger.info(
+      '[pdf-readiness] v1 contract not detected, falling back to networkidle',
+    );
+    // TODO: metrics.pdfReadinessFallbackTotal.inc()
+    await page.waitForNetworkIdle({ idleTime: 1000, timeout });
+  }
+
   return response;
 }

--- a/src/browser/previewPDF.ts
+++ b/src/browser/previewPDF.ts
@@ -8,12 +8,7 @@ import {
 import config from '../common/config';
 import { getHeaderAndFooterTemplates } from '../server/render-template';
 import { apiLogger } from '../common/logging';
-
-function delay(time: number) {
-  return new Promise(function (resolve) {
-    setTimeout(resolve, time);
-  });
-}
+import { navigateAndWaitForPdfReady } from './navigateAndWaitForPdfReady';
 
 const previewPdf = async (url: string) => {
   const createBuffer = async () => {
@@ -41,12 +36,7 @@ const previewPdf = async (url: string) => {
     await page.setCookie({ name: 'cs_jwt', value: 'bar', domain: 'localhost' });
     await page.setExtraHTTPHeaders(extraHeaders);
 
-    const pageStatus = await page.goto(url, {
-      waitUntil: 'networkidle2',
-    });
-
-    await delay(1000);
-    await page.waitForNetworkIdle();
+    const pageStatus = await navigateAndWaitForPdfReady(page, url);
     const { headerTemplate, footerTemplate } = getHeaderAndFooterTemplates();
 
     await setWindowProperty(

--- a/src/browser/tokenRefresh.spec.ts
+++ b/src/browser/tokenRefresh.spec.ts
@@ -1,4 +1,8 @@
-import { isTokenExpiringSoon, refreshAccessToken } from './tokenRefresh';
+import {
+  isTokenExpiringSoon,
+  refreshAccessToken,
+  TokenManager,
+} from './tokenRefresh';
 
 function makeJwt(payload: Record<string, unknown>): string {
   const header = Buffer.from(JSON.stringify({ alg: 'RS256' })).toString(
@@ -20,6 +24,7 @@ jest.mock('../common/logging', () => ({
   apiLogger: {
     debug: jest.fn(),
     error: jest.fn(),
+    warn: jest.fn(),
   },
 }));
 
@@ -106,7 +111,7 @@ describe('refreshAccessToken', () => {
     expect(body).toContain('client_id=cloud-services');
   });
 
-  it('returns null when SSO returns an error', async () => {
+  it('returns permanent error on 400 (invalid_grant)', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: false,
       status: 400,
@@ -114,14 +119,25 @@ describe('refreshAccessToken', () => {
     });
 
     const result = await refreshAccessToken('bad-refresh-token');
-    expect(result).toBeNull();
+    expect(result).toEqual({ error: 'permanent' });
   });
 
-  it('returns null on network failure', async () => {
+  it('returns transient error on 503', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: () => Promise.resolve('Service Unavailable'),
+    });
+
+    const result = await refreshAccessToken('some-token');
+    expect(result).toEqual({ error: 'transient' });
+  });
+
+  it('returns transient error on network failure', async () => {
     global.fetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
 
     const result = await refreshAccessToken('some-token');
-    expect(result).toBeNull();
+    expect(result).toEqual({ error: 'transient' });
   });
 
   it('returns null when SSO_URL is not configured', async () => {
@@ -137,5 +153,126 @@ describe('refreshAccessToken', () => {
     expect(mockFetch).not.toHaveBeenCalled();
 
     configModule.default.SSO_URL = origUrl;
+  });
+});
+
+describe('TokenManager', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('returns current token when not expiring', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 600;
+    const token = `Bearer ${makeJwt({ exp })}`;
+    const tm = new TokenManager(token, 'refresh-token');
+
+    const result = await tm.getValidToken();
+    expect(result).toBe(token);
+  });
+
+  it('refreshes when token is expiring', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 10;
+    const token = `Bearer ${makeJwt({ exp })}`;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ access_token: 'new-token' }),
+    });
+    const tm = new TokenManager(token, 'refresh-token');
+
+    const result = await tm.getValidToken();
+    expect(result).toBe('Bearer new-token');
+    expect(tm.currentToken).toBe('Bearer new-token');
+  });
+
+  it('coalesces concurrent getValidToken calls into single refresh', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 10;
+    const token = `Bearer ${makeJwt({ exp })}`;
+    let fetchCount = 0;
+    global.fetch = jest.fn().mockImplementation(async () => {
+      fetchCount++;
+      await new Promise((r) => setTimeout(r, 10));
+      return {
+        ok: true,
+        json: () => Promise.resolve({ access_token: 'coalesced-token' }),
+      };
+    });
+    const tm = new TokenManager(token, 'refresh-token');
+
+    const [r1, r2, r3] = await Promise.all([
+      tm.getValidToken(),
+      tm.getValidToken(),
+      tm.getValidToken(),
+    ]);
+
+    expect(fetchCount).toBe(1);
+    expect(r1).toBe('Bearer coalesced-token');
+    expect(r2).toBe('Bearer coalesced-token');
+    expect(r3).toBe('Bearer coalesced-token');
+  });
+
+  it('returns undefined when refresh fails permanently', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 10;
+    const token = `Bearer ${makeJwt({ exp })}`;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('invalid_grant'),
+    });
+    const tm = new TokenManager(token, 'refresh-token');
+
+    const result = await tm.getValidToken();
+    expect(result).toBeUndefined();
+  });
+
+  it('returns expiring token and warns on transient failure (503)', async () => {
+    const { apiLogger } = jest.requireMock('../common/logging');
+    const exp = Math.floor(Date.now() / 1000) + 10;
+    const token = `Bearer ${makeJwt({ exp })}`;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: () => Promise.resolve('service unavailable'),
+    });
+    const tm = new TokenManager(token, 'refresh-token');
+
+    const result = await tm.getValidToken();
+    expect(result).toBe(token);
+    expect(apiLogger.warn).toHaveBeenCalledWith(
+      '[token-refresh] Transient failure, proceeding with expiring token',
+    );
+  });
+
+  it('returns token as-is when no refresh token', async () => {
+    const tm = new TokenManager('Bearer some-token', undefined);
+
+    const result = await tm.getValidToken();
+    expect(result).toBe('Bearer some-token');
+  });
+
+  it('returns undefined when no auth at all', async () => {
+    const tm = new TokenManager(undefined, undefined);
+
+    const result = await tm.getValidToken();
+    expect(result).toBeUndefined();
+  });
+
+  it('stops retrying after permanent failure (400)', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 10;
+    const token = `Bearer ${makeJwt({ exp })}`;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      text: () => Promise.resolve('invalid_grant'),
+    });
+    const tm = new TokenManager(token, 'refresh-token');
+
+    await tm.getValidToken();
+    await tm.getValidToken();
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(tm.currentToken).toBe(token);
   });
 });

--- a/src/browser/tokenRefresh.ts
+++ b/src/browser/tokenRefresh.ts
@@ -3,6 +3,11 @@ import { apiLogger } from '../common/logging';
 
 const TOKEN_EXPIRY_BUFFER_MS = 60_000;
 
+export type RefreshResult =
+  | { accessToken: string }
+  | { error: 'permanent' | 'transient' }
+  | null;
+
 export function isTokenExpiringSoon(token: string): boolean {
   try {
     const payload = JSON.parse(
@@ -17,7 +22,7 @@ export function isTokenExpiringSoon(token: string): boolean {
 
 export async function refreshAccessToken(
   refreshToken: string,
-): Promise<{ accessToken: string } | null> {
+): Promise<RefreshResult> {
   if (!config.SSO_URL) {
     apiLogger.debug('[token-refresh] SSO_URL not configured, skipping refresh');
     return null;
@@ -41,7 +46,11 @@ export async function refreshAccessToken(
     if (!response.ok) {
       const text = await response.text();
       apiLogger.error(`[token-refresh] Failed: ${response.status} ${text}`);
-      return null;
+      // Keycloak returns 400 for invalid_grant (token expired/revoked) — won't recover
+      if (response.status === 400) {
+        return { error: 'permanent' };
+      }
+      return { error: 'transient' };
     }
 
     const data = (await response.json()) as { access_token: string };
@@ -49,6 +58,61 @@ export async function refreshAccessToken(
     return { accessToken: `Bearer ${data.access_token}` };
   } catch (error) {
     apiLogger.error(`[token-refresh] Error: ${error}`);
-    return null;
+    return { error: 'transient' };
+  }
+}
+
+export class TokenManager {
+  private token: string | undefined;
+  private readonly _refreshToken: string | undefined;
+  private refreshPromise: Promise<string | null> | null = null;
+  private permanentlyFailed = false;
+
+  constructor(authHeader?: string, refreshToken?: string) {
+    this.token = authHeader;
+    this._refreshToken = refreshToken;
+  }
+
+  async getValidToken(): Promise<string | undefined> {
+    if (!this.token || !this._refreshToken) {
+      return this.token;
+    }
+    if (!isTokenExpiringSoon(this.token.replace(/^Bearer\s+/i, ''))) {
+      return this.token;
+    }
+    return this.coalesce();
+  }
+
+  get currentToken(): string | undefined {
+    return this.token;
+  }
+
+  private async coalesce(): Promise<string | undefined> {
+    if (this.permanentlyFailed) {
+      return undefined;
+    }
+    if (!this.refreshPromise) {
+      this.refreshPromise = refreshAccessToken(this._refreshToken!)
+        .then((result) => {
+          if (result && 'accessToken' in result) {
+            this.token = result.accessToken;
+          } else if (result && result.error === 'permanent') {
+            this.permanentlyFailed = true;
+            apiLogger.debug(
+              '[token-refresh] Permanent failure, skipping future refreshes',
+            );
+            return null;
+          } else if (result && result.error === 'transient') {
+            apiLogger.warn(
+              '[token-refresh] Transient failure, proceeding with expiring token',
+            );
+          }
+          return this.token ?? null;
+        })
+        .finally(() => {
+          this.refreshPromise = null;
+        });
+    }
+    return (await this.refreshPromise) ?? undefined;
   }
 }

--- a/src/client/bootstrap.tsx
+++ b/src/client/bootstrap.tsx
@@ -6,7 +6,14 @@ import ScalprumProvider, {
   ScalprumComponentProps,
 } from '@scalprum/react-core';
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
-import { useEffect, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { createRoot } from 'react-dom/client';
 import { GeneratePayload } from '../common/types';
 import {
@@ -31,6 +38,69 @@ if (typeof state.fetchDataParams === 'string') {
 }
 if (typeof state.additionalData === 'string') {
   state.additionalData = JSON.parse(state.additionalData);
+}
+
+const isExplicitReadiness = state.renderReadiness === 'explicit-v1';
+const rootElement = document.getElementById('root');
+
+if (isExplicitReadiness && rootElement) {
+  rootElement.setAttribute('data-pdf-readiness-contract', 'v1');
+  rootElement.setAttribute('data-pdf-ready', 'false');
+}
+
+async function waitForFonts(timeoutMs = 10000): Promise<void> {
+  await Promise.race([
+    document.fonts.ready,
+    new Promise<void>((_, reject) =>
+      setTimeout(() => reject(new Error('Font loading timeout')), timeoutMs),
+    ),
+  ]).catch((err) => {
+    console.warn('[crc-pdf-generator] Font wait failed, proceeding:', err);
+  });
+}
+
+async function waitForImages(container: Element): Promise<void> {
+  const images = Array.from(container.querySelectorAll('img'));
+  const pending = images.filter((img) => !img.complete);
+  await Promise.all(
+    pending.map((img) =>
+      new Promise<void>((resolve) => {
+        const done = () => resolve();
+        img.addEventListener('load', done, { once: true });
+        img.addEventListener('error', done, { once: true });
+      }).then(async () => {
+        if (typeof img.decode === 'function') {
+          await img.decode().catch(() => {});
+        }
+      }),
+    ),
+  );
+}
+
+function waitForTwoRAFs(): Promise<void> {
+  return new Promise((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  );
+}
+
+async function runReadinessGates(container: Element): Promise<void> {
+  (window as any).__fontTimestamp = Date.now();
+  await waitForFonts();
+  (window as any).__fontTimestamp = Date.now();
+  await waitForImages(container);
+  await waitForTwoRAFs();
+}
+
+type PdfReadyContextType = {
+  onPdfReady: () => void;
+};
+
+const PdfReadyContext = createContext<PdfReadyContextType>({
+  onPdfReady: () => {},
+});
+
+export function usePdfReady(): PdfReadyContextType {
+  return useContext(PdfReadyContext);
 }
 
 const config: AppsConfig = {
@@ -120,6 +190,21 @@ const MetadataWrapper = () => {
     error: null,
     data: null,
   });
+
+  const pdfReadyResolverRef = useRef<(() => void) | null>(null);
+  const pdfReadyPromiseRef = useRef<Promise<void> | null>(null);
+
+  if (isExplicitReadiness && !pdfReadyPromiseRef.current) {
+    pdfReadyPromiseRef.current = new Promise<void>((resolve) => {
+      pdfReadyResolverRef.current = resolve;
+    });
+  }
+
+  const handlePdfReady = useCallback(() => {
+    (window as any).__callbackTimestamp = Date.now();
+    pdfReadyResolverRef.current?.();
+  }, []);
+
   async function getFetchMetadata() {
     try {
       const fn = await getModule<FetchData | undefined>(
@@ -162,6 +247,30 @@ const MetadataWrapper = () => {
     getFetchMetadata();
   }, []);
 
+  useEffect(() => {
+    if (!isExplicitReadiness || asyncState.loading || asyncState.error) return;
+
+    let cancelled = false;
+    (async () => {
+      if (pdfReadyPromiseRef.current) {
+        await pdfReadyPromiseRef.current;
+      }
+      if (cancelled) return;
+      const container = document.getElementById('root');
+      if (container) {
+        await runReadinessGates(container);
+        if (!cancelled) {
+          (window as any).__readyTimestamp = Date.now();
+          container.setAttribute('data-pdf-ready', 'true');
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [asyncState.loading, asyncState.error]);
+
   const { error, loading, data } = asyncState;
   if (error) {
     return <FetchErrorFallback error={error} />;
@@ -176,6 +285,7 @@ const MetadataWrapper = () => {
     {
       asyncData: { data: unknown };
       additionalData: Record<string, unknown> | undefined;
+      onPdfReady?: () => void;
     }
   > = {
     asyncData: { data },
@@ -184,12 +294,15 @@ const MetadataWrapper = () => {
     module: state.module,
     importName: state.importName,
     ErrorComponent: <FetchErrorFallback />,
+    onPdfReady: isExplicitReadiness ? handlePdfReady : undefined,
   };
   return (
-    // ensure CSS scope is applied
-    <div className={state.scope}>
-      <ScalprumComponent {...props} />
-    </div>
+    <PdfReadyContext.Provider value={{ onPdfReady: handlePdfReady }}>
+      {/* ensure CSS scope is applied */}
+      <div className={state.scope}>
+        <ScalprumComponent {...props} />
+      </div>
+    </PdfReadyContext.Provider>
   );
 };
 
@@ -226,7 +339,6 @@ const App = () => {
   );
 };
 
-const rootElement = document.getElementById('root');
 if (!rootElement) throw new Error('Root element not found');
 
 const root = createRoot(rootElement);

--- a/src/client/bootstrap.tsx
+++ b/src/client/bootstrap.tsx
@@ -21,6 +21,12 @@ import {
   IntegrationEndpointsMap,
 } from '../integration/endpoints';
 import { resolveInternalRouteKey } from '../common/integrationEndpoints';
+import {
+  createPdfReadyGate,
+  markPdfReady,
+  markReadinessContract,
+  runReadinessGates,
+} from './pdfReadiness';
 
 import 'react/jsx-runtime';
 
@@ -41,55 +47,7 @@ if (typeof state.additionalData === 'string') {
 }
 
 const isExplicitReadiness = state.renderReadiness === 'explicit-v1';
-const rootElement = document.getElementById('root');
-
-if (isExplicitReadiness && rootElement) {
-  rootElement.setAttribute('data-pdf-readiness-contract', 'v1');
-  rootElement.setAttribute('data-pdf-ready', 'false');
-}
-
-async function waitForFonts(timeoutMs = 10000): Promise<void> {
-  await Promise.race([
-    document.fonts.ready,
-    new Promise<void>((_, reject) =>
-      setTimeout(() => reject(new Error('Font loading timeout')), timeoutMs),
-    ),
-  ]).catch((err) => {
-    console.warn('[crc-pdf-generator] Font wait failed, proceeding:', err);
-  });
-}
-
-async function waitForImages(container: Element): Promise<void> {
-  const images = Array.from(container.querySelectorAll('img'));
-  const pending = images.filter((img) => !img.complete);
-  await Promise.all(
-    pending.map((img) =>
-      new Promise<void>((resolve) => {
-        const done = () => resolve();
-        img.addEventListener('load', done, { once: true });
-        img.addEventListener('error', done, { once: true });
-      }).then(async () => {
-        if (typeof img.decode === 'function') {
-          await img.decode().catch(() => {});
-        }
-      }),
-    ),
-  );
-}
-
-function waitForTwoRAFs(): Promise<void> {
-  return new Promise((resolve) =>
-    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
-  );
-}
-
-async function runReadinessGates(container: Element): Promise<void> {
-  (window as any).__fontTimestamp = Date.now();
-  await waitForFonts();
-  (window as any).__fontTimestamp = Date.now();
-  await waitForImages(container);
-  await waitForTwoRAFs();
-}
+markReadinessContract(document.getElementById('root'), state.renderReadiness);
 
 type PdfReadyContextType = {
   onPdfReady: () => void;
@@ -191,18 +149,16 @@ const MetadataWrapper = () => {
     data: null,
   });
 
-  const pdfReadyResolverRef = useRef<(() => void) | null>(null);
-  const pdfReadyPromiseRef = useRef<Promise<void> | null>(null);
+  const pdfReadyGateRef = useRef<ReturnType<typeof createPdfReadyGate> | null>(
+    null,
+  );
 
-  if (isExplicitReadiness && !pdfReadyPromiseRef.current) {
-    pdfReadyPromiseRef.current = new Promise<void>((resolve) => {
-      pdfReadyResolverRef.current = resolve;
-    });
+  if (isExplicitReadiness && !pdfReadyGateRef.current) {
+    pdfReadyGateRef.current = createPdfReadyGate();
   }
 
   const handlePdfReady = useCallback(() => {
-    (window as any).__callbackTimestamp = Date.now();
-    pdfReadyResolverRef.current?.();
+    pdfReadyGateRef.current?.resolve();
   }, []);
 
   async function getFetchMetadata() {
@@ -252,16 +208,15 @@ const MetadataWrapper = () => {
 
     let cancelled = false;
     (async () => {
-      if (pdfReadyPromiseRef.current) {
-        await pdfReadyPromiseRef.current;
+      if (pdfReadyGateRef.current) {
+        await pdfReadyGateRef.current.promise;
       }
       if (cancelled) return;
       const container = document.getElementById('root');
       if (container) {
         await runReadinessGates(container);
         if (!cancelled) {
-          (window as any).__readyTimestamp = Date.now();
-          container.setAttribute('data-pdf-ready', 'true');
+          markPdfReady(container);
         }
       }
     })();

--- a/src/client/pdfReadiness.spec.ts
+++ b/src/client/pdfReadiness.spec.ts
@@ -1,0 +1,200 @@
+import {
+  createPdfReadyGate,
+  markPdfReady,
+  markReadinessContract,
+  runReadinessGates,
+} from './pdfReadiness';
+
+type DomGlobals = {
+  window: Record<string, unknown>;
+  document: { fonts: { ready: Promise<unknown> } };
+  requestAnimationFrame?: (cb: (time: number) => void) => number;
+};
+
+function ensureDomGlobals() {
+  const g = globalThis as typeof globalThis & DomGlobals;
+  if (!(g as { window?: unknown }).window) {
+    (g as DomGlobals).window = g as unknown as Record<string, unknown>;
+  }
+  if (!(g as { document?: unknown }).document) {
+    Object.defineProperty(g, 'document', {
+      configurable: true,
+      writable: true,
+      value: {
+        fonts: { ready: Promise.resolve(undefined as unknown) },
+      },
+    });
+  }
+}
+
+ensureDomGlobals();
+
+function setFontsReady() {
+  const g = globalThis as typeof globalThis & DomGlobals;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (g.document as any).fonts = {
+    ready: Promise.resolve(),
+  };
+}
+function createMockRoot(attrs: Record<string, string> = {}) {
+  const attributes = { ...attrs };
+  return {
+    attributes,
+    setAttribute: (key: string, value: string) => {
+      attributes[key] = value;
+    },
+    getAttribute: (key: string) => attributes[key],
+    querySelectorAll: () => [],
+  } as unknown as Element;
+}
+
+describe('markReadinessContract', () => {
+  it('sets contract attributes when renderReadiness is explicit-v1', () => {
+    const root = createMockRoot();
+    markReadinessContract(root, 'explicit-v1');
+    expect(root.getAttribute('data-pdf-readiness-contract')).toBe('v1');
+    expect(root.getAttribute('data-pdf-ready')).toBe('false');
+  });
+
+  it('does nothing when renderReadiness is undefined', () => {
+    const root = createMockRoot();
+    markReadinessContract(root, undefined);
+    expect(root.getAttribute('data-pdf-readiness-contract')).toBeUndefined();
+  });
+
+  it('does nothing when root is null', () => {
+    expect(() => markReadinessContract(null, 'explicit-v1')).not.toThrow();
+  });
+});
+
+describe('createPdfReadyGate', () => {
+  it('does not resolve until resolve is called', async () => {
+    const gate = createPdfReadyGate();
+    let settled = false;
+    const pending = gate.promise.then(() => {
+      settled = true;
+    });
+
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    gate.resolve();
+    await pending;
+    expect(settled).toBe(true);
+    expect(
+      (globalThis as { __callbackTimestamp?: number }).__callbackTimestamp,
+    ).toEqual(expect.any(Number));
+  });
+});
+
+describe('runReadinessGates', () => {
+  const g = globalThis as typeof globalThis & DomGlobals;
+  const originalFonts = g.document.fonts;
+  const originalRaf = g.requestAnimationFrame;
+
+  beforeEach(() => {
+    setFontsReady();
+    g.requestAnimationFrame = (cb: (time: number) => void) => {
+      cb(0);
+      return 0;
+    };
+  });
+
+  afterEach(() => {
+    g.document.fonts = originalFonts;
+    g.requestAnimationFrame = originalRaf;
+    delete (g as { __fontTimestamp?: number }).__fontTimestamp;
+  });
+
+  it('stamps __fontTimestamp after fonts and completes gates', async () => {
+    const container = createMockRoot();
+    await runReadinessGates(container);
+    expect((g as { __fontTimestamp?: number }).__fontTimestamp).toEqual(
+      expect.any(Number),
+    );
+  });
+
+  it('waits for incomplete images before finishing', async () => {
+    const listeners: Record<string, Array<() => void>> = {};
+    const img = {
+      complete: false,
+      addEventListener: (event: string, handler: () => void) => {
+        listeners[event] = listeners[event] || [];
+        listeners[event].push(handler);
+      },
+      decode: jest.fn().mockResolvedValue(undefined),
+    };
+    const container = {
+      querySelectorAll: () => [img],
+    } as unknown as Element;
+
+    let gatesDone = false;
+    const gatesPromise = runReadinessGates(container).then(() => {
+      gatesDone = true;
+    });
+
+    // Flush until image listeners are registered (after fonts gate)
+    for (let i = 0; i < 10 && !listeners.load; i++) {
+      await Promise.resolve();
+    }
+    expect(gatesDone).toBe(false);
+    expect(listeners.load).toBeDefined();
+
+    listeners.load.forEach((fn) => fn());
+    await gatesPromise;
+    expect(gatesDone).toBe(true);
+    expect(img.decode).toHaveBeenCalled();
+  });
+});
+
+describe('markPdfReady', () => {
+  it('sets data-pdf-ready and stamps __readyTimestamp', () => {
+    const root = createMockRoot({ 'data-pdf-ready': 'false' });
+    markPdfReady(root);
+    expect(root.getAttribute('data-pdf-ready')).toBe('true');
+    expect(
+      (globalThis as { __readyTimestamp?: number }).__readyTimestamp,
+    ).toEqual(expect.any(Number));
+  });
+});
+
+describe('onPdfReady then gates ordering', () => {
+  const g = globalThis as typeof globalThis & DomGlobals;
+  const originalFonts = g.document.fonts;
+  const originalRaf = g.requestAnimationFrame;
+
+  beforeEach(() => {
+    setFontsReady();
+    g.requestAnimationFrame = (cb: (time: number) => void) => {
+      cb(0);
+      return 0;
+    };
+  });
+
+  afterEach(() => {
+    g.document.fonts = originalFonts;
+    g.requestAnimationFrame = originalRaf;
+  });
+
+  it('does not run gates until onPdfReady resolves the gate', async () => {
+    const gate = createPdfReadyGate();
+    const container = createMockRoot();
+    let gatesStarted = false;
+
+    const flow = (async () => {
+      await gate.promise;
+      gatesStarted = true;
+      await runReadinessGates(container);
+      markPdfReady(container);
+    })();
+
+    await Promise.resolve();
+    expect(gatesStarted).toBe(false);
+
+    gate.resolve();
+    await flow;
+
+    expect(gatesStarted).toBe(true);
+    expect(container.getAttribute('data-pdf-ready')).toBe('true');
+  });
+});

--- a/src/client/pdfReadiness.ts
+++ b/src/client/pdfReadiness.ts
@@ -1,0 +1,81 @@
+/**
+ * Explicit PDF readiness contract helpers (opt-in via renderReadiness: 'explicit-v1').
+ */
+
+export function markReadinessContract(
+  root: Element | null,
+  renderReadiness?: string,
+): void {
+  if (renderReadiness === 'explicit-v1' && root) {
+    root.setAttribute('data-pdf-readiness-contract', 'v1');
+    root.setAttribute('data-pdf-ready', 'false');
+  }
+}
+
+export async function waitForFonts(timeoutMs = 10000): Promise<void> {
+  await Promise.race([
+    document.fonts.ready,
+    new Promise<void>((_, reject) =>
+      setTimeout(() => reject(new Error('Font loading timeout')), timeoutMs),
+    ),
+  ]).catch((err) => {
+    console.warn('[crc-pdf-generator] Font wait failed, proceeding:', err);
+  });
+}
+
+export async function waitForImages(container: Element): Promise<void> {
+  const images = Array.from(container.querySelectorAll('img'));
+  const pending = images.filter((img) => !img.complete);
+  await Promise.all(
+    pending.map((img) =>
+      new Promise<void>((resolve) => {
+        const done = () => resolve();
+        img.addEventListener('load', done, { once: true });
+        img.addEventListener('error', done, { once: true });
+      }).then(async () => {
+        if (typeof img.decode === 'function') {
+          await img.decode().catch(() => {});
+        }
+      }),
+    ),
+  );
+}
+
+export function waitForTwoRAFs(): Promise<void> {
+  return new Promise((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  );
+}
+
+export async function runReadinessGates(container: Element): Promise<void> {
+  await waitForFonts();
+  // Test instrumentation: stamp after fonts so harnesses can assert gate ordering
+  (globalThis as { __fontTimestamp?: number }).__fontTimestamp = Date.now();
+  await waitForImages(container);
+  await waitForTwoRAFs();
+}
+
+export type PdfReadyGate = {
+  promise: Promise<void>;
+  resolve: () => void;
+};
+
+export function createPdfReadyGate(): PdfReadyGate {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return {
+    promise,
+    resolve: () => {
+      (globalThis as { __callbackTimestamp?: number }).__callbackTimestamp =
+        Date.now();
+      resolve();
+    },
+  };
+}
+
+export function markPdfReady(container: Element): void {
+  (globalThis as { __readyTimestamp?: number }).__readyTimestamp = Date.now();
+  container.setAttribute('data-pdf-ready', 'true');
+}

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -124,7 +124,7 @@ const defaultConfig: {
   pdfReadinessFallbackNetworkIdle:
     process.env.PDF_READINESS_FALLBACK_NETWORK_IDLE === 'true',
   pdfReadinessCapabilityDetectionMs: parseInt(
-    process.env.PDF_READINESS_CAPABILITY_DETECTION_MS || '500',
+    process.env.PDF_READINESS_CAPABILITY_DETECTION_MS || '2000',
     10,
   ),
   scalprum: {

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -45,6 +45,9 @@ const defaultConfig: {
   SSO_CLIENT_ID: string;
   ACCOUNT_ID: string;
   LOG_LEVEL: string;
+  pdfReadinessEnabled: boolean;
+  pdfReadinessFallbackNetworkIdle: boolean;
+  pdfReadinessCapabilityDetectionMs: number;
   scalprum: {
     // for proxy request to /api
     apiHost: string;
@@ -117,6 +120,13 @@ const defaultConfig: {
   JWT_COOKIE_NAME: 'cs_jwt',
   ACCOUNT_ID: '',
   LOG_LEVEL: process.env.LOG_LEVEL || 'debug',
+  pdfReadinessEnabled: process.env.PDF_READINESS_ENABLED !== 'false',
+  pdfReadinessFallbackNetworkIdle:
+    process.env.PDF_READINESS_FALLBACK_NETWORK_IDLE === 'true',
+  pdfReadinessCapabilityDetectionMs: parseInt(
+    process.env.PDF_READINESS_CAPABILITY_DETECTION_MS || '500',
+    10,
+  ),
   scalprum: {
     apiHost: process.env.API_HOST || 'blank',
     assetsHost: process.env.ASSETS_HOST || 'blank',

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -48,12 +48,6 @@ export type PuppeteerBrowserRequest = Request<
   GeneratePayload
 >;
 
-export type AuthState = {
-  authHeader?: string;
-  refreshToken?: string;
-  authCookie?: string;
-};
-
 export type PdfRequestBody = GeneratePayload & {
   uuid: string;
   url: string;

--- a/src/common/types.d.ts
+++ b/src/common/types.d.ts
@@ -16,6 +16,7 @@ export type GeneratePayload = {
   landscape?: boolean;
   identity?: string;
   authCookie?: string;
+  renderReadiness?: 'explicit-v1';
 };
 
 export type PreviewHandlerRequest = Request<

--- a/src/server/cluster.ts
+++ b/src/server/cluster.ts
@@ -3,6 +3,8 @@ import config from '../common/config';
 const BROWSER_TIMEOUT = 120_000;
 import { CHROMIUM_PATH } from '../browser/helpers';
 import { apiLogger } from '../common/logging';
+import PdfCache, { PdfStatus } from '../common/pdfCache';
+import { UpdateStatus } from './utils';
 
 export const GetPupCluster = async () => {
   const CONCURRENCY_DEFAULT = 2;
@@ -37,8 +39,35 @@ export const GetPupCluster = async () => {
   });
 
   // Add error handlers to prevent unhandled rejections from cluster tasks
-  cluster.on('taskerror', (err: Error, data: unknown) => {
+  cluster.on('taskerror', async (err: Error, data: unknown) => {
     apiLogger.error('Puppeteer cluster task error:', err, 'data:', data);
+
+    // After all retries exhausted, record component failure and invalidate collection
+    if (data && typeof data === 'object' && 'collectionId' in data) {
+      const collectionId = (data as { collectionId: string }).collectionId;
+      const componentId = (data as { componentId?: string }).componentId;
+      const order = (data as { order?: number }).order;
+      const message = err instanceof Error ? err.message : String(err);
+      apiLogger.error(
+        `Collection ${collectionId} failed after retries: ${message}`,
+      );
+
+      // Record component as Failed if componentId available
+      if (componentId) {
+        await UpdateStatus({
+          collectionId,
+          status: PdfStatus.Failed,
+          filepath: '',
+          componentId,
+          order,
+          error: message,
+        });
+        // UpdateStatus → verifyCollection → invalidateCollection (happens here)
+      } else {
+        // No componentId - directly invalidate collection
+        PdfCache.getInstance().invalidateCollection(collectionId, message);
+      }
+    }
   });
 
   return cluster;

--- a/src/server/routes/routes.spec.ts
+++ b/src/server/routes/routes.spec.ts
@@ -1,4 +1,67 @@
+jest.mock('../cluster', () => ({
+  cluster: {
+    queue: jest.fn(),
+    idle: jest.fn(),
+  },
+}));
+
+jest.mock('../../browser/clusterTask', () => ({
+  generatePdf: jest.fn(),
+}));
+
+jest.mock('../../browser/previewPDF', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../render-template', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('./createInternalProxies', () => ({
+  __esModule: true,
+  default: () => [],
+}));
+
+jest.mock('http-proxy-middleware', () => ({
+  createProxyMiddleware: jest.fn(),
+}));
+
+jest.mock('express-http-context', () => ({
+  get: jest.fn(),
+}));
+
+jest.mock('../../common/kafka', () => ({
+  produceMessage: jest.fn(),
+  KafkaClient: jest.fn(),
+}));
+
+jest.mock('../../common/store', () => ({
+  store: {
+    getObject: jest.fn(),
+    uploadPDF: jest.fn(),
+  },
+}));
+
+jest.mock('../../common/config', () => ({
+  __esModule: true,
+  default: {
+    webPort: 8000,
+    APIPrefix: '/api/crc-pdf-generator',
+    JWT_COOKIE_NAME: 'cs_jwt',
+    AUTHORIZATION_CONTEXT_KEY: 'x-pdf-auth',
+    REFRESH_TOKEN_CONTEXT_KEY: 'x-pdf-refresh-token',
+    IDENTITY_HEADER_KEY: 'x-rh-identity',
+    OPTIONS_HEADER_NAME: 'x-pdf-gen-options',
+    kafka: { brokers: [] },
+    scalprum: { apiHost: 'blank', assetsHost: 'blank' },
+  },
+}));
+
 import PdfCache, { PdfStatus, PDFComponent } from '../../common/pdfCache';
+import { getPdfRequestBody } from './routes';
+import { GeneratePayload } from '../../common/types';
 
 describe('Status endpoint error propagation', () => {
   const pdfCache = PdfCache.getInstance();
@@ -91,5 +154,35 @@ describe('Status endpoint error propagation', () => {
       expect(collection.status).toBe(PdfStatus.Failed);
       expect(collection.error).toBe('Network error fetching data');
     });
+  });
+});
+
+describe('getPdfRequestBody', () => {
+  it('includes renderReadiness in the puppeteer URL when provided', () => {
+    const payload: GeneratePayload = {
+      manifestLocation: '/apps/landing/fed-mods.json',
+      scope: 'landing',
+      module: './PdfEntry',
+      renderReadiness: 'explicit-v1',
+    };
+
+    const body = getPdfRequestBody(payload);
+    const url = new URL(body.url);
+
+    expect(url.searchParams.get('renderReadiness')).toBe('explicit-v1');
+    expect(body.renderReadiness).toBe('explicit-v1');
+  });
+
+  it('omits renderReadiness from the puppeteer URL when not provided', () => {
+    const payload: GeneratePayload = {
+      manifestLocation: '/apps/landing/fed-mods.json',
+      scope: 'landing',
+      module: './PdfEntry',
+    };
+
+    const body = getPdfRequestBody(payload);
+    const url = new URL(body.url);
+
+    expect(url.searchParams.has('renderReadiness')).toBe(false);
   });
 });

--- a/src/server/routes/routes.ts
+++ b/src/server/routes/routes.ts
@@ -9,7 +9,6 @@ import renderTemplate from '../render-template';
 import config from '../../common/config';
 import previewPdf from '../../browser/previewPDF';
 import {
-  AuthState,
   GenerateHandlerRequest,
   PdfRequestBody,
   PuppeteerBrowserRequest,
@@ -21,6 +20,7 @@ import { store } from '../../common/store';
 import { UpdateStatus } from '../utils';
 import { cluster } from '../cluster';
 import { generatePdf } from '../../browser/clusterTask';
+import { TokenManager } from '../../browser/tokenRefresh';
 import { createProxyMiddleware } from 'http-proxy-middleware';
 import createInternalProxies from './createInternalProxies';
 import instanceConfig from '../../common/config';
@@ -115,7 +115,7 @@ function addProxy(req: GenerateHandlerRequest) {
   }
 }
 
-function getPdfRequestBody(payload: GeneratePayload): PdfRequestBody {
+export function getPdfRequestBody(payload: GeneratePayload): PdfRequestBody {
   const {
     manifestLocation,
     module,
@@ -123,6 +123,7 @@ function getPdfRequestBody(payload: GeneratePayload): PdfRequestBody {
     fetchDataParams,
     additionalData,
     importName,
+    renderReadiness,
   } = payload;
   const uuid = crypto.randomUUID();
   const requestURL = new URL(`http://localhost:${config?.webPort}/puppeteer`);
@@ -143,6 +144,9 @@ function getPdfRequestBody(payload: GeneratePayload): PdfRequestBody {
       'additionalData',
       JSON.stringify(payload.additionalData),
     );
+  }
+  if (renderReadiness) {
+    requestURL.searchParams.append('renderReadiness', renderReadiness);
   }
 
   return {
@@ -210,25 +214,26 @@ router.post(
 
     try {
       const requiredCalls = requestConfigs.length;
-      const authState: AuthState = {
-        authHeader:
-          httpContext.get(config.AUTHORIZATION_CONTEXT_KEY) ||
+      const tokenManager = new TokenManager(
+        httpContext.get(config.AUTHORIZATION_CONTEXT_KEY) ||
           process.env.MOCK_TOKEN,
-        refreshToken: httpContext.get(config.REFRESH_TOKEN_CONTEXT_KEY),
-        authCookie: httpContext.get(config.JWT_COOKIE_NAME),
-      };
+        httpContext.get(config.REFRESH_TOKEN_CONTEXT_KEY),
+      );
+      const authCookie: string | undefined = httpContext.get(
+        config.JWT_COOKIE_NAME,
+      );
       if (requiredCalls === 1) {
         const pdfDetails = getPdfRequestBody(requestConfigs[0]);
         apiLogger.debug(`Single call to generator queued for ${collectionId}`);
         pdfCache.setExpectedLength(collectionId, requiredCalls);
-        generatePdf(pdfDetails, collectionId, 1, authState);
+        generatePdf(pdfDetails, collectionId, 1, tokenManager, authCookie);
         return res.status(202).send({ statusID: collectionId });
       }
       pdfCache.setExpectedLength(collectionId, requiredCalls);
       apiLogger.debug(`Queueing ${requiredCalls} for ${collectionId}`);
       for (let x = 0; x < Number(requiredCalls); x++) {
         const pdfDetails = getPdfRequestBody(requestConfigs[x]);
-        generatePdf(pdfDetails, collectionId, x + 1, authState);
+        generatePdf(pdfDetails, collectionId, x + 1, tokenManager, authCookie);
       }
 
       return res.status(202).send({ statusID: collectionId });
@@ -371,6 +376,9 @@ router.get(`/preview`, async (req: PreviewHandlerRequest, res) => {
       'fetchDataParams',
       JSON.stringify(req.query.fetchDataParams),
     );
+  }
+  if (req.query.renderReadiness) {
+    pdfUrl.searchParams.append('renderReadiness', req.query.renderReadiness);
   }
 
   try {


### PR DESCRIPTION
## Summary
- Adds an opt-in explicit readiness contract (`renderReadiness: 'explicit-v1'`) so templates signal when rendering is done, instead of relying on `networkidle2` + `waitForNetworkIdle` (which can resolve early when batched requests have >1s gaps).
- Client bootstrap sets `data-pdf-readiness-contract` / `data-pdf-ready`, exposes `onPdfReady`, then runs fonts + images + 2 rAF gates before marking ready.
- Wires `renderReadiness` through the puppeteer URL (P0 fix), documents the contract, raises capability-detection default to 2000ms, and includes E2E fixtures plus unit tests. Aligns auth with `TokenManager` and restores `cluster.queue` task data for main’s retry/`taskerror` path.

## Test plan
- [ ] Unit: `npm test -- --testPathPattern='pdfReadiness|navigateAndWaitForPdfReady|clusterTask|tokenRefresh|routes.spec'`
- [ ] E2E: `npm run test:e2e` (batch-gap fixture waits for batch 2; errors/timeouts short-circuit)
- [ ] Manual: create PDF with `renderReadiness: 'explicit-v1'` and confirm generation waits for `onPdfReady` + gates
- [ ] Manual: legacy payload without `renderReadiness` still works (fallback / flag behavior as configured)
- [ ] Confirm `PDF_READINESS_ENABLED=false` restores prior network-idle wait


Made with [Cursor](https://cursor.com)