### PR TITLE
perf: eliminate redundant work via caching and memoization

### DIFF
--- a/src/browser/clusterTask.spec.ts
+++ b/src/browser/clusterTask.spec.ts
@@ -426,4 +426,177 @@ describe('generatePdf', () => {
       expect(global.fetch).toHaveBeenCalledTimes(2);
     });
   });
+
+  describe('response handler', () => {
+    function getResponseHandler(): (response: unknown) => Promise<void> {
+      const calls = mockPage.on.mock.calls.filter(
+        ([event]: [string]) => event === 'response',
+      );
+      return calls[calls.length - 1][1] as (response: unknown) => Promise<void>;
+    }
+
+    it('logs error responses with status >= 400', async () => {
+      const { apiLogger } = jest.requireMock('../common/logging');
+      await generatePdf(
+        makePdfRequest(),
+        'coll-resp-err',
+        1,
+        makeTokenManager(),
+      );
+
+      const handler = getResponseHandler();
+      await handler({
+        status: () => 502,
+        url: () => 'https://example.com/api/data',
+        text: () => Promise.resolve('Bad Gateway'),
+        ok: () => false,
+        headers: () => ({}),
+      });
+
+      expect(apiLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('502'),
+      );
+      expect(apiLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('Bad Gateway'),
+      );
+    });
+
+    it('logs <unreadable> when error response body cannot be read', async () => {
+      const { apiLogger } = jest.requireMock('../common/logging');
+      await generatePdf(
+        makePdfRequest(),
+        'coll-resp-unread',
+        1,
+        makeTokenManager(),
+      );
+
+      const handler = getResponseHandler();
+      await handler({
+        status: () => 500,
+        url: () => 'https://example.com/api/fail',
+        text: () => Promise.reject(new Error('body stream consumed')),
+        ok: () => false,
+        headers: () => ({}),
+      });
+
+      expect(apiLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('<unreadable>'),
+      );
+    });
+
+    it('caches successful JS/CSS asset responses', async () => {
+      await generatePdf(
+        makePdfRequest(),
+        'coll-resp-cache',
+        1,
+        makeTokenManager(),
+      );
+
+      const handler = getResponseHandler();
+      const assetBody = Buffer.from('console.log("cached")');
+      await handler({
+        status: () => 200,
+        url: () => 'https://example.com/apps/my-app/bundle.js?v=1',
+        ok: () => true,
+        buffer: () => Promise.resolve(assetBody),
+        headers: () => ({ 'content-type': 'application/javascript' }),
+      });
+
+      // Trigger a second request for the same asset via the request handler
+      const requestCalls = mockPage.on.mock.calls.filter(
+        ([event]: [string]) => event === 'request',
+      );
+      const requestHandler = requestCalls[requestCalls.length - 1][1];
+
+      const respondFn = jest.fn();
+      const continueFn = jest.fn();
+      await requestHandler({
+        method: () => 'GET',
+        url: () => 'https://example.com/apps/my-app/bundle.js?v=2',
+        respond: respondFn,
+        continue: continueFn,
+      });
+
+      expect(respondFn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 200,
+          contentType: 'application/javascript',
+          body: assetBody,
+        }),
+      );
+      expect(continueFn).not.toHaveBeenCalled();
+    });
+
+    it('does not cache non-asset responses', async () => {
+      await generatePdf(
+        makePdfRequest(),
+        'coll-resp-no-cache',
+        1,
+        makeTokenManager(),
+      );
+
+      const handler = getResponseHandler();
+      await handler({
+        status: () => 200,
+        url: () => 'https://example.com/api/data',
+        ok: () => true,
+        buffer: () => Promise.resolve(Buffer.from('data')),
+        headers: () => ({ 'content-type': 'application/json' }),
+      });
+
+      // Non-asset URL should not be cached — request should continue normally
+      const requestCalls = mockPage.on.mock.calls.filter(
+        ([event]: [string]) => event === 'request',
+      );
+      const requestHandler = requestCalls[requestCalls.length - 1][1];
+
+      const respondFn = jest.fn();
+      const continueFn = jest.fn();
+      await requestHandler({
+        method: () => 'GET',
+        url: () => 'https://example.com/api/data',
+        respond: respondFn,
+        continue: continueFn,
+      });
+
+      expect(continueFn).toHaveBeenCalled();
+      expect(respondFn).not.toHaveBeenCalled();
+    });
+
+    it('does not cache error responses as assets', async () => {
+      await generatePdf(
+        makePdfRequest(),
+        'coll-resp-err-no-cache',
+        1,
+        makeTokenManager(),
+      );
+
+      const handler = getResponseHandler();
+      await handler({
+        status: () => 404,
+        url: () => 'https://example.com/apps/my-app/missing.js',
+        ok: () => false,
+        text: () => Promise.resolve('Not Found'),
+        headers: () => ({}),
+      });
+
+      // 404 asset should not be cached — request should continue normally
+      const requestCalls = mockPage.on.mock.calls.filter(
+        ([event]: [string]) => event === 'request',
+      );
+      const requestHandler = requestCalls[requestCalls.length - 1][1];
+
+      const respondFn = jest.fn();
+      const continueFn = jest.fn();
+      await requestHandler({
+        method: () => 'GET',
+        url: () => 'https://example.com/apps/my-app/missing.js',
+        respond: respondFn,
+        continue: continueFn,
+      });
+
+      expect(continueFn).toHaveBeenCalled();
+      expect(respondFn).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/browser/clusterTask.ts
+++ b/src/browser/clusterTask.ts
@@ -71,20 +71,6 @@ async function runPageTask(
           apiLogger.debug(`[Headless log] ${msg.text()}`);
         });
 
-        page.on('response', async (response) => {
-          if (response.status() >= 400) {
-            let body = '';
-            try {
-              body = await response.text();
-            } catch {
-              body = '<unreadable>';
-            }
-            apiLogger.debug(
-              `[Headless response] ${response.status()} ${response.url()} | body=${body}`,
-            );
-          }
-        });
-
         await setWindowProperty(
           page,
           'customPuppeteerParams',
@@ -141,20 +127,34 @@ async function runPageTask(
           await interceptedRequest.continue();
         });
 
-        page.on('response', async (resp) => {
-          const respUrl = resp.url();
+        page.on('response', async (response) => {
+          const respUrl = response.url();
+
+          if (response.status() >= 400) {
+            let body = '';
+            try {
+              body = await response.text();
+            } catch {
+              body = '<unreadable>';
+            }
+            apiLogger.debug(
+              `[Headless response] ${response.status()} ${respUrl} | body=${body}`,
+            );
+            return;
+          }
+
           if (
-            resp.ok() &&
+            response.ok() &&
             respUrl.includes('/apps/') &&
             /\.(js|css)(\?|$)/.test(respUrl) &&
             !assetCache.has(assetCacheKey(respUrl))
           ) {
             try {
-              const body = await resp.buffer();
+              const body = await response.buffer();
               assetCache.set(assetCacheKey(respUrl), {
                 body,
                 contentType:
-                  resp.headers()['content-type'] ||
+                  response.headers()['content-type'] ||
                   (respUrl.match(/\.css(\?|$)/)
                     ? 'text/css'
                     : 'application/javascript'),

--- a/src/browser/tokenRefresh.spec.ts
+++ b/src/browser/tokenRefresh.spec.ts
@@ -1,8 +1,4 @@
-import {
-  isTokenExpiringSoon,
-  refreshAccessToken,
-  TokenManager,
-} from './tokenRefresh';
+import { refreshAccessToken, TokenManager } from './tokenRefresh';
 
 function makeJwt(payload: Record<string, unknown>): string {
   const header = Buffer.from(JSON.stringify({ alg: 'RS256' })).toString(
@@ -27,35 +23,6 @@ jest.mock('../common/logging', () => ({
     warn: jest.fn(),
   },
 }));
-
-describe('isTokenExpiringSoon', () => {
-  it('returns true when token expires within 60 seconds', () => {
-    const exp = Math.floor(Date.now() / 1000) + 30;
-    expect(isTokenExpiringSoon(makeJwt({ exp }))).toBe(true);
-  });
-
-  it('returns true when token is already expired', () => {
-    const exp = Math.floor(Date.now() / 1000) - 100;
-    expect(isTokenExpiringSoon(makeJwt({ exp }))).toBe(true);
-  });
-
-  it('returns false when token has plenty of time left', () => {
-    const exp = Math.floor(Date.now() / 1000) + 600;
-    expect(isTokenExpiringSoon(makeJwt({ exp }))).toBe(false);
-  });
-
-  it('returns false for malformed token', () => {
-    expect(isTokenExpiringSoon('not-a-jwt')).toBe(false);
-  });
-
-  it('returns false for empty string', () => {
-    expect(isTokenExpiringSoon('')).toBe(false);
-  });
-
-  it('returns false when payload has no exp claim', () => {
-    expect(isTokenExpiringSoon(makeJwt({ sub: 'user' }))).toBe(false);
-  });
-});
 
 describe('refreshAccessToken', () => {
   const originalFetch = global.fetch;
@@ -274,5 +241,103 @@ describe('TokenManager', () => {
 
     expect(global.fetch).toHaveBeenCalledTimes(1);
     expect(tm.currentToken).toBe(token);
+  });
+
+  it('parses token expiry once at construction', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 600;
+    const token = `Bearer ${makeJwt({ exp })}`;
+    global.fetch = jest.fn();
+    const tm = new TokenManager(token, 'refresh-token');
+
+    // Multiple checks should not re-parse
+    await tm.getValidToken();
+    await tm.getValidToken();
+    await tm.getValidToken();
+
+    // Should never need refresh because token is not expiring
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('updates cached expiry after token refresh', async () => {
+    const oldExp = Math.floor(Date.now() / 1000) + 10;
+    const oldToken = `Bearer ${makeJwt({ exp: oldExp })}`;
+    const newExp = Math.floor(Date.now() / 1000) + 600;
+    const newToken = makeJwt({ exp: newExp });
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ access_token: newToken }),
+    });
+
+    const tm = new TokenManager(oldToken, 'refresh-token');
+    const firstCall = await tm.getValidToken();
+
+    // After refresh, should not need another refresh
+    const secondCall = await tm.getValidToken();
+
+    // Should only fetch once (during first call)
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(firstCall).toContain(newToken);
+    expect(secondCall).toContain(newToken);
+  });
+
+  it('handles malformed tokens gracefully', async () => {
+    const tm = new TokenManager('Bearer malformed', 'refresh-token');
+
+    const result = await tm.getValidToken();
+    expect(result).toBe('Bearer malformed');
+  });
+
+  it('refreshes an already-expired token', async () => {
+    const exp = Math.floor(Date.now() / 1000) - 100;
+    const token = `Bearer ${makeJwt({ exp })}`;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ access_token: 'fresh-token' }),
+    });
+    const tm = new TokenManager(token, 'refresh-token');
+
+    const result = await tm.getValidToken();
+    expect(result).toBe('Bearer fresh-token');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refresh token without exp claim', async () => {
+    const token = `Bearer ${makeJwt({ sub: 'user', iss: 'test' })}`;
+    global.fetch = jest.fn();
+    const tm = new TokenManager(token, 'refresh-token');
+
+    const result = await tm.getValidToken();
+    expect(result).toBe(token);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not refresh token with non-numeric exp claim', async () => {
+    const token = `Bearer ${makeJwt({ exp: 'not-a-number' })}`;
+    global.fetch = jest.fn();
+    const tm = new TokenManager(token, 'refresh-token');
+
+    const result = await tm.getValidToken();
+    expect(result).toBe(token);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not refresh token with null exp claim', async () => {
+    const token = `Bearer ${makeJwt({ exp: null })}`;
+    global.fetch = jest.fn();
+    const tm = new TokenManager(token, 'refresh-token');
+
+    const result = await tm.getValidToken();
+    expect(result).toBe(token);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('treats empty auth header as no-auth (skips refresh)', async () => {
+    global.fetch = jest.fn();
+    const tm = new TokenManager('', 'refresh-token');
+
+    const result = await tm.getValidToken();
+    expect(result).toBe('');
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });

--- a/src/browser/tokenRefresh.ts
+++ b/src/browser/tokenRefresh.ts
@@ -6,15 +6,17 @@ const TOKEN_EXPIRY_BUFFER_MS = 60_000;
 export type RefreshResult =
   { accessToken: string } | { error: 'permanent' | 'transient' } | null;
 
-export function isTokenExpiringSoon(token: string): boolean {
+function parseTokenExpiry(token: string): number | null {
   try {
     const payload = JSON.parse(
       Buffer.from(token.split('.')[1], 'base64').toString(),
     );
-    const expiresAt = payload.exp * 1000;
-    return Date.now() + TOKEN_EXPIRY_BUFFER_MS > expiresAt;
+    if (typeof payload.exp !== 'number' || !isFinite(payload.exp)) {
+      return null;
+    }
+    return payload.exp * 1000;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -65,17 +67,30 @@ export class TokenManager {
   private readonly _refreshToken: string | undefined;
   private refreshPromise: Promise<string | null> | null = null;
   private permanentlyFailed = false;
+  private tokenExpiresAt: number | null = null;
 
   constructor(authHeader?: string, refreshToken?: string) {
     this.token = authHeader;
     this._refreshToken = refreshToken;
+    if (authHeader) {
+      this.updateTokenExpiry(authHeader);
+    }
+  }
+
+  private updateTokenExpiry(token: string): void {
+    this.tokenExpiresAt = parseTokenExpiry(token.replace(/^Bearer\s+/i, ''));
+  }
+
+  private isTokenExpiringSoon(): boolean {
+    if (this.tokenExpiresAt === null) return false;
+    return Date.now() + TOKEN_EXPIRY_BUFFER_MS > this.tokenExpiresAt;
   }
 
   async getValidToken(): Promise<string | undefined> {
     if (!this.token || !this._refreshToken) {
       return this.token;
     }
-    if (!isTokenExpiringSoon(this.token.replace(/^Bearer\s+/i, ''))) {
+    if (!this.isTokenExpiringSoon()) {
       return this.token;
     }
     return this.coalesce();
@@ -94,6 +109,7 @@ export class TokenManager {
         .then((result) => {
           if (result && 'accessToken' in result) {
             this.token = result.accessToken;
+            this.updateTokenExpiry(result.accessToken);
           } else if (result && result.error === 'permanent') {
             this.permanentlyFailed = true;
             apiLogger.debug(

--- a/src/server/render-template/index.spec.ts
+++ b/src/server/render-template/index.spec.ts
@@ -1,0 +1,63 @@
+import fs from 'fs';
+
+jest.mock('../../common/config', () => ({
+  __esModule: true,
+  default: {
+    endpoints: {},
+    IS_PRODUCTION: false,
+  },
+}));
+
+// We need to import after mocking dependencies
+let getHeaderAndFooterTemplates: typeof import('./index').getHeaderAndFooterTemplates;
+
+describe('getHeaderAndFooterTemplates', () => {
+  beforeEach(() => {
+    // Re-import to get fresh module state
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('./index');
+    getHeaderAndFooterTemplates = mod.getHeaderAndFooterTemplates;
+  });
+
+  it('reads template files on first call', () => {
+    const result = getHeaderAndFooterTemplates();
+
+    expect(result).toHaveProperty('headerTemplate');
+    expect(result).toHaveProperty('footerTemplate');
+    expect(typeof result.headerTemplate).toBe('string');
+    expect(typeof result.footerTemplate).toBe('string');
+  });
+
+  it('returns cached templates on subsequent calls without re-reading files', () => {
+    const readFileSync = jest.spyOn(fs, 'readFileSync');
+
+    const first = getHeaderAndFooterTemplates();
+    const callsAfterFirst = readFileSync.mock.calls.length;
+
+    const second = getHeaderAndFooterTemplates();
+    const callsAfterSecond = readFileSync.mock.calls.length;
+
+    const third = getHeaderAndFooterTemplates();
+    const callsAfterThird = readFileSync.mock.calls.length;
+
+    // fs.readFileSync should only be called during first call (2 times for header and footer)
+    expect(callsAfterFirst).toBeGreaterThan(0);
+    expect(callsAfterSecond).toBe(callsAfterFirst); // No additional calls
+    expect(callsAfterThird).toBe(callsAfterFirst); // No additional calls
+
+    // All calls should return the same reference (cached)
+    expect(first).toBe(second);
+    expect(second).toBe(third);
+
+    readFileSync.mockRestore();
+  });
+
+  it('templates contain rendered content', () => {
+    const result = getHeaderAndFooterTemplates();
+
+    // Both should have content (rendered React components)
+    expect(result.headerTemplate.length).toBeGreaterThan(0);
+    expect(result.footerTemplate.length).toBeGreaterThan(0);
+  });
+});

--- a/src/server/render-template/index.tsx
+++ b/src/server/render-template/index.tsx
@@ -6,10 +6,19 @@ import Header from './Header';
 import Footer from './Footer';
 import instanceConfig from '../../common/config';
 
+let cachedTemplates: {
+  headerTemplate: string;
+  footerTemplate: string;
+} | null = null;
+
 export function getHeaderAndFooterTemplates(): {
   headerTemplate: string;
   footerTemplate: string;
 } {
+  if (cachedTemplates) {
+    return cachedTemplates;
+  }
+
   const root = process.cwd();
   const headerBase = fs.readFileSync(
     path.resolve(root, 'public/templates/header-template.html'),
@@ -21,7 +30,7 @@ export function getHeaderAndFooterTemplates(): {
     { encoding: 'utf-8' },
   );
 
-  return {
+  cachedTemplates = {
     headerTemplate: headerBase.replace(
       '<div id="content"></div>',
       renderToStaticMarkup(<Header />),
@@ -31,6 +40,8 @@ export function getHeaderAndFooterTemplates(): {
       renderToStaticMarkup(<Footer />),
     ),
   };
+
+  return cachedTemplates;
 }
 
 function renderTemplate(payload: GeneratePayload) {


### PR DESCRIPTION
Three targeted performance improvements that eliminate repeated computation on the hot path.

### Description

[RHCLOUD-48978](https://issues.redhat.com/browse/RHCLOUD-48978)

**1. Merge duplicate `page.on('response')` handlers (`clusterTask.ts`)**
Two separate response listeners were registered on every Puppeteer page — one for logging 4xx/5xx responses, one for caching JS/CSS assets. Merged into a single handler with an early-return on error status, eliminating double listener overhead and clarifying mutual exclusivity.

**2. Cache JWT expiry parsing in `TokenManager` (`tokenRefresh.ts`)**
`isTokenExpiringSoon()` re-parsed the JWT payload on every `getValidToken()` call (which fires on every PDF request). The parsed expiry is now stored as `tokenExpiresAt` at construction time and updated after each token refresh. The helper is now a private instance method.

**3. Cache header/footer templates (`render-template/index.tsx`)**
`getHeaderAndFooterTemplates()` called `fs.readFileSync` × 2 and `renderToStaticMarkup` × 2 on every invocation. Templates are now computed once and stored in a module-level variable.

---

### How to test locally

```bash
npm test -- --testPathPattern="tokenRefresh|clusterTask|render-template"
```

All 48 tests pass.

---

### Anything reviewers should know?

- `isTokenExpiringSoon` is no longer exported (it was only used inside `TokenManager`). Its direct unit tests have been replaced by `TokenManager`-level behavioural tests.
- The template cache is module-scoped, so tests use `jest.resetModules()` between cases to get a fresh cache.

---

### Checklist
- [x] Tests: new/updated tests cover the change
- [x] API: spec updated if endpoints changed (or N/A)
- [x] Migrations: backwards compatible if schema changed (or N/A)
- [x] Dependencies: no known impact to dependent services
- [x] Security: reviewed against [secure coding checklist](https://github.com/RedHatInsights/secure-coding-checklist) (or N/A)

### AI disclosure
Assisted by: Claude Code

[RHCLOUD-48978]: https://redhat.atlassian.net/browse/RHCLOUD-48978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ