### PR TITLE
fix: dead code cleanup and shared constants extraction

### DIFF
--- a/src/browser/clusterTask.ts
+++ b/src/browser/clusterTask.ts
@@ -12,8 +12,7 @@ import { cluster } from '../server/cluster';
 import { Page } from 'puppeteer';
 import { PDFDocument } from 'pdf-lib';
 import { TokenManager } from './tokenRefresh';
-
-const BROWSER_TIMEOUT = 120_000;
+import { BROWSER_TIMEOUT } from '../common/constants';
 
 const assetCache = new Map<string, { body: Buffer; contentType: string }>();
 

--- a/src/browser/helpers.ts
+++ b/src/browser/helpers.ts
@@ -14,15 +14,6 @@ export const sanitizeFilepath = (input: string) => {
   return input.replace(SANITIZE_FILEPATH, '');
 };
 
-export const MaxWorkers = 4;
-
-export const margins = {
-  top: '2cm',
-  bottom: '2cm',
-  right: '1cm',
-  left: '1cm',
-};
-
 function getChromiumExecutablePath() {
   const home = process.env.HOME || '/root';
   const paths = glob.sync(
@@ -54,45 +45,3 @@ export const setWindowProperty = (page: Page, name: string, value: string) =>
       }
     })
   `);
-
-type PdfStatus = {
-  [statusID: string]: {
-    status: string;
-    filepath: string;
-  };
-};
-
-type PdfEntry = {
-  status: string;
-  filepath: string;
-};
-
-class PdfCache {
-  private static instance: PdfCache;
-  private data: PdfStatus;
-
-  private constructor() {
-    this.data = {};
-  }
-
-  public static getInstance(): PdfCache {
-    if (!PdfCache.instance) {
-      PdfCache.instance = new PdfCache();
-    }
-    return PdfCache.instance;
-  }
-
-  public setItem(id: string, status: PdfEntry): void {
-    this.data[id] = { ...status };
-  }
-
-  public getItem(id: string): PdfEntry {
-    return this.data[id];
-  }
-
-  public deleteItem(id: string) {
-    delete this.data[id];
-  }
-}
-
-export default PdfCache;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,1 @@
+export const BROWSER_TIMEOUT = 120_000;

--- a/src/common/pdfCache.ts
+++ b/src/common/pdfCache.ts
@@ -357,7 +357,7 @@ class PdfCache {
     // Sort the pages for the correct finalized PDF order
     const sortedSlices = this.sortComponents(collection.components);
     apiLogger.debug(`Merging slices for collection ${collectionId}`);
-    const tmpdir = `/tmp/${collectionId}-components/*`;
+    const tmpdir = `/tmp/${collectionId}-components/`;
     ensureDirSync(tmpdir);
     try {
       const merger = new PDFMerger();

--- a/src/server/cluster.ts
+++ b/src/server/cluster.ts
@@ -1,6 +1,6 @@
 import { Cluster } from 'puppeteer-cluster';
 import config from '../common/config';
-const BROWSER_TIMEOUT = 120_000;
+import { BROWSER_TIMEOUT } from '../common/constants';
 import { CHROMIUM_PATH } from '../browser/helpers';
 import { apiLogger } from '../common/logging';
 import PdfCache, { PdfStatus } from '../common/pdfCache';


### PR DESCRIPTION
## Summary

- **Fix glob wildcard in tmpdir path** (`pdfCache.ts:360`): `ensureDirSync` was creating a directory literally named `*` instead of a plain directory. Removed the trailing `*`.
- **Remove dead code from `helpers.ts`**: Deleted unused `PdfCache` class (duplicate of real implementation in `common/pdfCache.ts`), unused `MaxWorkers` constant, unused `margins` object, and associated types.
- **Extract `BROWSER_TIMEOUT` to shared constants**: Both `clusterTask.ts` and `cluster.ts` declared `const BROWSER_TIMEOUT = 120_000` independently. Created `src/common/constants.ts` and replaced local declarations with imports.

~60 lines removed, 4 added. Zero behavioral change.

[RHCLOUD-48975](https://issues.redhat.com/browse/RHCLOUD-48975)

## Test plan

- [x] `npm run build:production` — compiles successfully
- [x] `npm test` — all tests pass
- [x] `npm run lint` — clean
- [x] `npm run circular` — no circular dependencies

[RHCLOUD-48975]: https://redhat.atlassian.net/browse/RHCLOUD-48975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ