### PR TITLE
fix(security): harden Puppeteer against SSRF and header exfiltration

### DIFF
--- a/src/browser/clusterTask.spec.ts
+++ b/src/browser/clusterTask.spec.ts
@@ -123,6 +123,35 @@ function initCollection(collectionId: string) {
   pdfCache.setExpectedLength(collectionId, 1);
 }
 
+type MockInterceptedRequest = {
+  url: () => string;
+  method: () => string;
+  headers: () => Record<string, string>;
+  continue: jest.Mock;
+  respond: jest.Mock;
+};
+
+function makeInterceptedRequest(url: string): MockInterceptedRequest {
+  return {
+    url: () => url,
+    method: () => 'GET',
+    headers: () => ({}),
+    continue: jest.fn(),
+    respond: jest.fn(),
+  };
+}
+
+async function getRequestInterceptorResult(url: string): Promise<jest.Mock> {
+  const handler = mockPage.on.mock.calls.find(
+    ([event]: [string]) => event === 'request',
+  )?.[1];
+  const req = makeInterceptedRequest(url);
+  if (handler) {
+    await handler(req);
+  }
+  return req.continue;
+}
+
 describe('generatePdf', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -164,15 +193,28 @@ describe('generatePdf', () => {
       expect(mockPage.close).toHaveBeenCalled();
     });
 
-    it('sets auth header from token manager', async () => {
+    it('forwards auth header to same-origin (localhost) requests', async () => {
       const tm = makeTokenManager('Bearer my-token');
       await generatePdf(makePdfRequest(), 'coll-1', 1, tm);
 
-      expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
+      const continueMock = await getRequestInterceptorResult(
+        'http://localhost:8000/api/something',
+      );
+      expect(continueMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          'x-pdf-auth': 'Bearer my-token',
+          headers: expect.objectContaining({ 'x-pdf-auth': 'Bearer my-token' }),
         }),
       );
+    });
+
+    it('does not forward auth header to cross-origin requests', async () => {
+      const tm = makeTokenManager('Bearer my-token');
+      await generatePdf(makePdfRequest(), 'coll-1', 1, tm);
+
+      const continueMock = await getRequestInterceptorResult(
+        'https://cdn.example.com/script.js',
+      );
+      expect(continueMock).toHaveBeenCalledWith();
     });
   });
 
@@ -309,9 +351,14 @@ describe('generatePdf', () => {
 
       expect(global.fetch).toHaveBeenCalledTimes(1);
       expect(tm.currentToken).toBe('Bearer refreshed-token');
-      expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
+      const continueMock = await getRequestInterceptorResult(
+        'http://localhost:8000/api/something',
+      );
+      expect(continueMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          'x-pdf-auth': 'Bearer refreshed-token',
+          headers: expect.objectContaining({
+            'x-pdf-auth': 'Bearer refreshed-token',
+          }),
         }),
       );
     });
@@ -327,11 +374,12 @@ describe('generatePdf', () => {
       await generatePdf(makePdfRequest(), 'coll-no-refresh', 1, tm);
 
       expect(tm.currentToken).toBe(EXPIRING_TOKEN);
-      expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
-        expect.not.objectContaining({
-          'x-pdf-auth': expect.anything(),
-        }),
+      const continueMock = await getRequestInterceptorResult(
+        'http://localhost:8000/api/something',
       );
+      // When auth header is absent, continue() is called without overrides
+      // (no extraHeaders means no localhost header injection either)
+      expect(continueMock).toHaveBeenCalledWith();
     });
 
     it('does not refresh when token is still fresh', async () => {
@@ -369,9 +417,10 @@ describe('generatePdf', () => {
       expect(UpdateStatus).toHaveBeenLastCalledWith(
         expect.objectContaining({ status: PdfStatus.Generated }),
       );
-      expect(mockPage.setExtraHTTPHeaders).toHaveBeenCalledWith(
-        expect.not.objectContaining({ 'x-pdf-auth': expect.anything() }),
+      const continueMock = await getRequestInterceptorResult(
+        'http://localhost:8000/api/something',
       );
+      expect(continueMock).toHaveBeenCalledWith();
     });
 
     it('coalesces concurrent refreshes into a single SSO call', async () => {

--- a/src/browser/clusterTask.ts
+++ b/src/browser/clusterTask.ts
@@ -137,7 +137,21 @@ async function runPageTask(
               return;
             }
           }
-          await interceptedRequest.continue();
+          // Auth headers are forwarded only to same-origin (localhost) requests
+          // to prevent credential exfiltration via cross-origin requests.
+          let isSameOrigin = false;
+          try {
+            isSameOrigin = new URL(reqUrl).hostname === 'localhost';
+          } catch {
+            // unparseable URL — treat as cross-origin
+          }
+          if (isSameOrigin && Object.keys(extraHeaders).length > 0) {
+            await interceptedRequest.continue({
+              headers: { ...interceptedRequest.headers(), ...extraHeaders },
+            });
+          } else {
+            await interceptedRequest.continue();
+          }
         });
 
         page.on('response', async (resp) => {
@@ -163,8 +177,6 @@ async function runPageTask(
             }
           }
         });
-
-        await page.setExtraHTTPHeaders(extraHeaders);
 
         const pageResponse = await page.goto(url, {
           waitUntil: 'networkidle2',

--- a/src/common/kafka.ts
+++ b/src/common/kafka.ts
@@ -64,8 +64,12 @@ export const getKafkaSASL = (brokers: KafkaBroker[]) => {
   return undefined;
 };
 
-const KafkaClient = () => {
-  const brokers = config?.kafka.brokers;
+const KafkaClient = (): Kafka | null => {
+  const brokers = config?.kafka?.brokers ?? [];
+  if (brokers.length === 0) {
+    apiLogger.debug('no brokers configured, Kafka disabled');
+    return null;
+  }
   const sasl = getKafkaSASL(brokers);
   const ssl = getKafkaSSL(brokers);
   if (ssl && sasl) {
@@ -89,6 +93,10 @@ const pdfCache = PdfCache.getInstance();
 const kafka = KafkaClient();
 
 export async function produceMessage(topic: string, message: unknown) {
+  if (!kafka) {
+    apiLogger.debug('Kafka disabled, skipping produce');
+    return;
+  }
   const producer = kafka.producer();
 
   await producer.connect();
@@ -101,6 +109,10 @@ export async function produceMessage(topic: string, message: unknown) {
 }
 
 export async function consumeMessages(topic: string) {
+  if (!kafka) {
+    apiLogger.debug('Kafka disabled, skipping consume');
+    return;
+  }
   const consumer = kafka.consumer({ groupId: `pdf-gen-${os.hostname()}` });
   await consumer.connect();
   // Don't read from the beginning. Messages from not-yet-expired objects on the topic

--- a/src/server/render-template/index.tsx
+++ b/src/server/render-template/index.tsx
@@ -40,6 +40,14 @@ function renderTemplate(payload: GeneratePayload) {
     { encoding: 'utf-8' },
   );
 
+  // Only expose endpoint keys to the browser — never leak internal hostnames/ports.
+  const endpointKeys = Object.fromEntries(
+    Object.keys(instanceConfig.endpoints).map((k) => [
+      k,
+      { app: instanceConfig.endpoints[k]?.app ?? k, name: '' },
+    ]),
+  );
+
   const template = baseTemplate.replace(
     '<script id="initial-state"></script>',
     `<script id="initial-state">window.__initialState__ = ${JSON.stringify(
@@ -47,7 +55,7 @@ function renderTemplate(payload: GeneratePayload) {
       null,
       2,
     )};
-window.__endpoints__ = ${JSON.stringify(instanceConfig.endpoints, null, 2)}
+window.__endpoints__ = ${JSON.stringify(endpointKeys, null, 2)}
 window.IS_PRODUCTION = ${instanceConfig.IS_PRODUCTION}</script>`,
   );
 

--- a/src/server/routes/routes.ts
+++ b/src/server/routes/routes.ts
@@ -432,6 +432,16 @@ router.post(
 );
 
 router.get(`/preview`, async (req: PreviewHandlerRequest, res) => {
+  const validationError = validatePayload(req.query);
+  if (validationError) {
+    return res.status(400).json({
+      error: {
+        status: 400,
+        statusText: 'Bad Request',
+        description: `Invalid field "${validationError.field}": ${validationError.message}`,
+      },
+    });
+  }
   addProxy(req as any);
   const pdfUrl = new URL(`http://localhost:${config?.webPort}/puppeteer`);
   pdfUrl.searchParams.append('manifestLocation', req.query.manifestLocation);

--- a/src/server/routes/routes.ts
+++ b/src/server/routes/routes.ts
@@ -7,6 +7,7 @@ import { Router, Request } from 'express';
 import httpContext from 'express-http-context';
 import renderTemplate from '../render-template';
 import config from '../../common/config';
+import { MANIFEST_ALLOWED_ORIGINS, validatePayload } from '../utils';
 import previewPdf from '../../browser/previewPDF';
 import {
   GenerateHandlerRequest,
@@ -183,6 +184,24 @@ router.get('/puppeteer', (req: PuppeteerBrowserRequest, res, _next) => {
     }
 
     const HTMLTemplate: string = renderTemplate(payload);
+    // Defense-in-depth: restrict what the headless browser page can load/execute.
+    const allowedOriginsWithScheme = [...MANIFEST_ALLOWED_ORIGINS]
+      .map((host) => `https://${host}`)
+      .join(' ');
+    res.setHeader(
+      'Content-Security-Policy',
+      [
+        "default-src 'none'",
+        `script-src 'self' 'unsafe-inline' ${allowedOriginsWithScheme}`,
+        `style-src 'self' 'unsafe-inline' ${allowedOriginsWithScheme}`,
+        `img-src 'self' data: blob: ${allowedOriginsWithScheme}`,
+        `font-src 'self' data: ${allowedOriginsWithScheme}`,
+        "connect-src 'self'",
+        "object-src 'none'",
+        "base-uri 'self'",
+        "form-action 'none'",
+      ].join('; '),
+    );
     res.send(HTMLTemplate);
   } catch (error) {
     // render error to DOM to retrieve the error content from puppeteer
@@ -209,6 +228,19 @@ router.post(
     const requestConfigs = Array.isArray(req.body.payload)
       ? req.body.payload
       : [req.body.payload];
+
+    for (const payload of requestConfigs) {
+      const validationError = validatePayload(payload);
+      if (validationError) {
+        return res.status(400).json({
+          error: {
+            status: 400,
+            statusText: 'Bad Request',
+            description: `Invalid field "${validationError.field}": ${validationError.message}`,
+          },
+        });
+      }
+    }
 
     const configHeaders: string | string[] | undefined =
       req.headers[config?.OPTIONS_HEADER_NAME];

--- a/src/server/routes/routes.ts
+++ b/src/server/routes/routes.ts
@@ -222,7 +222,6 @@ router.get(`${config?.APIPrefix}/v1/hello`, (_req, res) => {
 router.post(
   `${config?.APIPrefix}/v2/create`,
   async (req: GenerateHandlerRequest, res) => {
-    addProxy(req);
     const collectionId = crypto.randomUUID();
     // for testing purposes
     const requestConfigs = Array.isArray(req.body.payload)
@@ -241,6 +240,8 @@ router.post(
         });
       }
     }
+
+    addProxy(req);
 
     const configHeaders: string | string[] | undefined =
       req.headers[config?.OPTIONS_HEADER_NAME];

--- a/src/server/utils.spec.ts
+++ b/src/server/utils.spec.ts
@@ -1,7 +1,7 @@
 import { validatePayload } from './utils';
 
 const valid = {
-  manifestLocation: 'https://cloud.redhat.com/apps/foo/fed-mods.json',
+  manifestLocation: 'https://console.redhat.com/apps/foo/fed-mods.json',
   module: './App',
   scope: 'fooApp',
 };
@@ -19,6 +19,32 @@ describe('validatePayload', () => {
           manifestLocation: '/apps/foo/fed-mods.json',
         }),
       ).toBeNull();
+    });
+
+    it('accepts stage console origin', () => {
+      expect(
+        validatePayload({
+          ...valid,
+          manifestLocation:
+            'https://console.stage.redhat.com/apps/foo/fed-mods.json',
+        }),
+      ).toBeNull();
+    });
+
+    it('rejects disallowed https origins', () => {
+      const err = validatePayload({
+        ...valid,
+        manifestLocation: 'https://attacker.com/evil.json',
+      });
+      expect(err?.field).toBe('manifestLocation');
+    });
+
+    it('rejects subdomain attacks on allowed origins', () => {
+      const err = validatePayload({
+        ...valid,
+        manifestLocation: 'https://evil.console.redhat.com/foo.json',
+      });
+      expect(err?.field).toBe('manifestLocation');
     });
 
     it('rejects http:// URLs', () => {

--- a/src/server/utils.spec.ts
+++ b/src/server/utils.spec.ts
@@ -83,6 +83,22 @@ describe('validatePayload', () => {
       });
       expect(err?.field).toBe('manifestLocation');
     });
+
+    it('rejects protocol-relative URLs', () => {
+      const err = validatePayload({
+        ...valid,
+        manifestLocation: '//attacker.com/evil.json',
+      });
+      expect(err?.field).toBe('manifestLocation');
+    });
+
+    it('rejects backslash after leading slash', () => {
+      const err = validatePayload({
+        ...valid,
+        manifestLocation: '/\\attacker.com/evil.json',
+      });
+      expect(err?.field).toBe('manifestLocation');
+    });
   });
 
   describe('module', () => {
@@ -99,6 +115,11 @@ describe('validatePayload', () => {
 
     it('rejects path traversal', () => {
       const err = validatePayload({ ...valid, module: '../../../etc/passwd' });
+      expect(err?.field).toBe('module');
+    });
+
+    it('rejects path traversal with ./ prefix', () => {
+      const err = validatePayload({ ...valid, module: './../../etc/passwd' });
       expect(err?.field).toBe('module');
     });
 
@@ -122,5 +143,42 @@ describe('validatePayload', () => {
       const err = validatePayload({ ...valid, scope: '' });
       expect(err?.field).toBe('scope');
     });
+  });
+});
+
+describe('validatePayload rejects malformed payloads', () => {
+  it('rejects null', () => {
+    const err = validatePayload(null);
+    expect(err?.field).toBe('payload');
+  });
+
+  it('rejects undefined', () => {
+    const err = validatePayload(undefined);
+    expect(err?.field).toBe('payload');
+  });
+
+  it('rejects a scalar', () => {
+    const err = validatePayload(42);
+    expect(err?.field).toBe('payload');
+  });
+
+  it('rejects non-string manifestLocation', () => {
+    const err = validatePayload({
+      manifestLocation: 123,
+      module: './App',
+      scope: 'x',
+    });
+    expect(err?.field).toBe('manifestLocation');
+  });
+});
+
+describe('validatePayload covers /preview inputs', () => {
+  it('rejects attacker manifestLocation', () => {
+    const err = validatePayload({
+      manifestLocation: 'https://attacker.com/evil.json',
+      module: './App',
+      scope: 'fooApp',
+    });
+    expect(err?.field).toBe('manifestLocation');
   });
 });

--- a/src/server/utils.spec.ts
+++ b/src/server/utils.spec.ts
@@ -1,0 +1,100 @@
+import { validatePayload } from './utils';
+
+const valid = {
+  manifestLocation: 'https://cloud.redhat.com/apps/foo/fed-mods.json',
+  module: './App',
+  scope: 'fooApp',
+};
+
+describe('validatePayload', () => {
+  it('returns null for valid payload', () => {
+    expect(validatePayload(valid)).toBeNull();
+  });
+
+  describe('manifestLocation', () => {
+    it('accepts relative JSON paths', () => {
+      expect(
+        validatePayload({
+          ...valid,
+          manifestLocation: '/apps/foo/fed-mods.json',
+        }),
+      ).toBeNull();
+    });
+
+    it('rejects http:// URLs', () => {
+      const err = validatePayload({
+        ...valid,
+        manifestLocation: 'http://example.com/fed-mods.json',
+      });
+      expect(err?.field).toBe('manifestLocation');
+    });
+
+    it('rejects javascript: URIs', () => {
+      const err = validatePayload({
+        ...valid,
+        manifestLocation: 'javascript:alert(1)',
+      });
+      expect(err?.field).toBe('manifestLocation');
+    });
+
+    it('rejects data: URIs', () => {
+      const err = validatePayload({
+        ...valid,
+        manifestLocation: 'data:text/html,<h1>x</h1>',
+      });
+      expect(err?.field).toBe('manifestLocation');
+    });
+
+    it('rejects empty string', () => {
+      const err = validatePayload({ ...valid, manifestLocation: '' });
+      expect(err?.field).toBe('manifestLocation');
+    });
+
+    it('rejects non-.json relative path', () => {
+      const err = validatePayload({
+        ...valid,
+        manifestLocation: '/apps/foo/notjson',
+      });
+      expect(err?.field).toBe('manifestLocation');
+    });
+  });
+
+  describe('module', () => {
+    it('accepts ./SubPath/Module', () => {
+      expect(
+        validatePayload({ ...valid, module: './SubPath/Module' }),
+      ).toBeNull();
+    });
+
+    it('rejects bare name without ./', () => {
+      const err = validatePayload({ ...valid, module: 'App' });
+      expect(err?.field).toBe('module');
+    });
+
+    it('rejects path traversal', () => {
+      const err = validatePayload({ ...valid, module: '../../../etc/passwd' });
+      expect(err?.field).toBe('module');
+    });
+
+    it('rejects empty string', () => {
+      const err = validatePayload({ ...valid, module: '' });
+      expect(err?.field).toBe('module');
+    });
+  });
+
+  describe('scope', () => {
+    it('accepts scoped package names', () => {
+      expect(validatePayload({ ...valid, scope: '@org/scope' })).toBeNull();
+    });
+
+    it('rejects strings with spaces', () => {
+      const err = validatePayload({ ...valid, scope: 'bad scope' });
+      expect(err?.field).toBe('scope');
+    });
+
+    it('rejects empty string', () => {
+      const err = validatePayload({ ...valid, scope: '' });
+      expect(err?.field).toBe('scope');
+    });
+  });
+});

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -53,7 +53,7 @@ export function sanitizeRecord(
 // manifestLocation must be a relative path or an absolute URL from allowed origins.
 // Prevents javascript:, data:, and other dangerous URI schemes from being
 // loaded by the headless browser.
-const RELATIVE_MANIFEST_RE = /^\/[^\s<>"]*\.json$/;
+const RELATIVE_MANIFEST_RE = /^\/(?![/\\])[^\s<>"\\]*\.json$/;
 
 const defaultManifestOrigins = [
   'console.redhat.com',
@@ -95,14 +95,24 @@ const SCOPE_RE = /^[A-Za-z0-9_@/-]+$/;
 
 export type PayloadValidationError = { field: string; message: string };
 
-export function validatePayload(payload: {
-  manifestLocation: string;
-  module: string;
-  scope: string;
-}): PayloadValidationError | null {
+export function validatePayload(
+  payload: unknown,
+): PayloadValidationError | null {
   if (
-    !payload.manifestLocation ||
-    !isValidManifestLocation(payload.manifestLocation)
+    payload === null ||
+    payload === undefined ||
+    typeof payload !== 'object'
+  ) {
+    return {
+      field: 'payload',
+      message: 'payload must be a non-null object',
+    };
+  }
+  const p = payload as Record<string, unknown>;
+  if (
+    typeof p.manifestLocation !== 'string' ||
+    !p.manifestLocation ||
+    !isValidManifestLocation(p.manifestLocation)
   ) {
     return {
       field: 'manifestLocation',
@@ -110,13 +120,13 @@ export function validatePayload(payload: {
         'manifestLocation must be a relative JSON path or an absolute https:// URL from allowed origins',
     };
   }
-  if (!payload.module || !MODULE_RE.test(payload.module)) {
+  if (typeof p.module !== 'string' || !p.module || !MODULE_RE.test(p.module)) {
     return {
       field: 'module',
       message: 'module must be a relative module path (e.g. "./App")',
     };
   }
-  if (!payload.scope || !SCOPE_RE.test(payload.scope)) {
+  if (typeof p.scope !== 'string' || !p.scope || !SCOPE_RE.test(p.scope)) {
     return {
       field: 'scope',
       message: 'scope must be an alphanumeric identifier',

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -50,10 +50,42 @@ export function sanitizeRecord(
   return sanitizedRecord;
 }
 
-// manifestLocation must be a relative path or an absolute https:// URL.
+// manifestLocation must be a relative path or an absolute URL from allowed origins.
 // Prevents javascript:, data:, and other dangerous URI schemes from being
 // loaded by the headless browser.
-const MANIFEST_RE = /^(https:\/\/[^\s<>"]+|\/[^\s<>"]*\.json)$/;
+const RELATIVE_MANIFEST_RE = /^\/[^\s<>"]*\.json$/;
+
+const defaultManifestOrigins = [
+  'console.redhat.com',
+  'console.stage.redhat.com',
+];
+const envManifestOrigins =
+  process.env.MANIFEST_ALLOWED_ORIGINS?.split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean) ?? [];
+const manifestOrigins =
+  envManifestOrigins.length > 0 ? envManifestOrigins : defaultManifestOrigins;
+
+export const MANIFEST_ALLOWED_ORIGINS = new Set(manifestOrigins);
+if (process.env.NODE_ENV !== 'production') {
+  MANIFEST_ALLOWED_ORIGINS.add('localhost');
+}
+
+function isValidManifestLocation(manifestLocation: string): boolean {
+  if (RELATIVE_MANIFEST_RE.test(manifestLocation)) {
+    return true;
+  }
+
+  try {
+    const url = new URL(manifestLocation);
+    const isLocalhost = url.hostname === 'localhost';
+    const protocolOk =
+      url.protocol === 'https:' || (isLocalhost && url.protocol === 'http:');
+    return protocolOk && MANIFEST_ALLOWED_ORIGINS.has(url.hostname);
+  } catch {
+    return false;
+  }
+}
 
 // module must be a relative webpack module specifier, e.g. "./App".
 const MODULE_RE = /^\.\/[A-Za-z0-9_/.-]+$/;
@@ -70,12 +102,12 @@ export function validatePayload(payload: {
 }): PayloadValidationError | null {
   if (
     !payload.manifestLocation ||
-    !MANIFEST_RE.test(payload.manifestLocation)
+    !isValidManifestLocation(payload.manifestLocation)
   ) {
     return {
       field: 'manifestLocation',
       message:
-        'manifestLocation must be a relative JSON path or an absolute https:// URL',
+        'manifestLocation must be a relative JSON path or an absolute https:// URL from allowed origins',
     };
   }
   if (!payload.module || !MODULE_RE.test(payload.module)) {

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -49,3 +49,46 @@ export function sanitizeRecord(
   });
   return sanitizedRecord;
 }
+
+// manifestLocation must be a relative path or an absolute https:// URL.
+// Prevents javascript:, data:, and other dangerous URI schemes from being
+// loaded by the headless browser.
+const MANIFEST_RE = /^(https:\/\/[^\s<>"]+|\/[^\s<>"]*\.json)$/;
+
+// module must be a relative webpack module specifier, e.g. "./App".
+const MODULE_RE = /^\.\/[A-Za-z0-9_/.-]+$/;
+
+// scope must be a valid npm package name or identifier.
+const SCOPE_RE = /^[A-Za-z0-9_@/-]+$/;
+
+export type PayloadValidationError = { field: string; message: string };
+
+export function validatePayload(payload: {
+  manifestLocation: string;
+  module: string;
+  scope: string;
+}): PayloadValidationError | null {
+  if (
+    !payload.manifestLocation ||
+    !MANIFEST_RE.test(payload.manifestLocation)
+  ) {
+    return {
+      field: 'manifestLocation',
+      message:
+        'manifestLocation must be a relative JSON path or an absolute https:// URL',
+    };
+  }
+  if (!payload.module || !MODULE_RE.test(payload.module)) {
+    return {
+      field: 'module',
+      message: 'module must be a relative module path (e.g. "./App")',
+    };
+  }
+  if (!payload.scope || !SCOPE_RE.test(payload.scope)) {
+    return {
+      field: 'scope',
+      message: 'scope must be an alphanumeric identifier',
+    };
+  }
+  return null;
+}

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -88,7 +88,7 @@ function isValidManifestLocation(manifestLocation: string): boolean {
 }
 
 // module must be a relative webpack module specifier, e.g. "./App".
-const MODULE_RE = /^\.\/[A-Za-z0-9_/.-]+$/;
+const MODULE_RE = /^\.\/(?!.*\.\.)[\w/.-]+$/;
 
 // scope must be a valid npm package name or identifier.
 const SCOPE_RE = /^[A-Za-z0-9_@/-]+$/;


### PR DESCRIPTION
## Summary

- Restrict auth headers (`x-rh-identity`, `x-pdf-auth`, etc.) to same-origin (localhost) requests in Puppeteer — prevents credential exfiltration via cross-origin sub-requests from federated modules
- Validate `manifestLocation`, `module`, and `scope` inputs on both `/v2/create` and `/preview` routes — blocks SSRF via attacker-controlled manifest URLs, path traversal in module specifiers, and injection via scope
- Add Content-Security-Policy to the `/puppeteer` HTML response as defense-in-depth — limits script/style/connect sources to the origin allowlist
- Stop leaking internal service topology (hostnames, ports) via `window.__endpoints__` — expose only endpoint keys
- Cherry-pick Kafka null-guard fix from RHCLOUD-49243 to fix pre-existing test failures

---

### Description

[RHCLOUD-49589](https://issues.redhat.com/browse/RHCLOUD-49589)

---

### How to test locally

1. `npm test` — all 137 tests pass (13 suites)
2. `npm run lint` — clean
3. `npm run circular` — no circular dependencies
4. Verify validation rejects malicious inputs:
   - `curl 'http://localhost:8000/preview?manifestLocation=https://attacker.com/evil.json&scope=x&module=./X'` → 400
   - `curl -X POST http://localhost:8000/api/crc-pdf-generator/v2/create -H 'Content-Type: application/json' -d '{"payload":{"manifestLocation":"javascript:alert(1)","module":"./App","scope":"x"}}'` → 400
5. Verify legitimate payloads still work (console.redhat.com / console.stage.redhat.com origins, relative JSON paths)

---

### Anything reviewers should know?

- `MANIFEST_ALLOWED_ORIGINS` can be overridden via the `MANIFEST_ALLOWED_ORIGINS` env var (comma-separated hostnames). Defaults to `console.redhat.com, console.stage.redhat.com`. `localhost` is added automatically in non-production.
- The CSP maps all allowed origins to `https://` scheme. Dev assets load through the same-origin `/apps` proxy so `'self'` covers them — no functional impact expected.
- The Kafka cherry-pick (`ba3f863`) is identical to the fix on RHCLOUD-49243; it guards against undefined `config.kafka` in test environments.

---

### Checklist
- [x] Tests: new/updated tests cover the change
- [x] API: spec updated if endpoints changed (or N/A)
- [x] Migrations: backwards compatible if schema changed (or N/A)
- [x] Dependencies: no known impact to dependent services
- [x] Security: reviewed against [secure coding checklist](https://github.com/RedHatInsights/secure-coding-checklist) (or N/A)

### AI disclosure
Assisted by: Claude Code (Opus 4.6)

[RHCLOUD-49589]: https://redhat.atlassian.net/browse/RHCLOUD-49589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ