### PR TITLE
feat: rewrite preview to use shared cluster

### DIFF
--- a/src/browser/previewPDF.spec.ts
+++ b/src/browser/previewPDF.spec.ts
@@ -1,0 +1,213 @@
+const mockPage = {
+  setViewport: jest.fn(),
+  on: jest.fn(),
+  goto: jest.fn().mockResolvedValue({ ok: () => true, statusText: () => 'OK' }),
+  waitForNetworkIdle: jest.fn(),
+  setExtraHTTPHeaders: jest.fn(),
+  setCookie: jest.fn(),
+  pdf: jest.fn().mockResolvedValue(Buffer.from('%PDF-mock')),
+  close: jest.fn(),
+};
+
+const mockExecute = jest.fn(
+  (taskFn: ({ page }: { page: unknown }) => Promise<unknown>) =>
+    taskFn({ page: mockPage }),
+);
+
+jest.mock('puppeteer', () => ({
+  __esModule: true,
+  default: {
+    launch: jest.fn().mockResolvedValue({
+      newPage: jest.fn().mockResolvedValue(mockPage),
+      close: jest.fn(),
+    }),
+  },
+}));
+
+jest.mock('../server/cluster', () => ({
+  cluster: {
+    execute: mockExecute,
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { default: previewPdf } = require('./previewPDF');
+
+jest.mock('../common/config', () => ({
+  __esModule: true,
+  default: {
+    IS_PRODUCTION: false,
+    webPort: 8000,
+  },
+}));
+
+jest.mock('../common/logging', () => ({
+  apiLogger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock('./helpers', () => ({
+  pageWidth: 1024,
+  pageHeight: 768,
+  setWindowProperty: jest.fn(),
+}));
+
+jest.mock('../server/render-template', () => ({
+  getHeaderAndFooterTemplates: () => ({
+    headerTemplate: '<div>header</div>',
+    footerTemplate: '<div>footer</div>',
+  }),
+}));
+
+const { setWindowProperty } = jest.requireMock('./helpers');
+
+describe('previewPdf', () => {
+  const TEST_URL = 'http://localhost:8000/puppeteer?scope=test';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPage.goto.mockResolvedValue({
+      ok: () => true,
+      statusText: () => 'OK',
+    });
+    mockPage.pdf.mockResolvedValue(Buffer.from('%PDF-mock'));
+  });
+
+  describe('cluster integration', () => {
+    it('uses shared cluster.execute instead of launching a standalone browser', async () => {
+      await previewPdf(TEST_URL);
+
+      expect(mockExecute).toHaveBeenCalledTimes(1);
+      expect(mockExecute).toHaveBeenCalledWith(expect.any(Function));
+    });
+  });
+
+  describe('page setup ordering', () => {
+    it('calls setWindowProperty BEFORE page.goto', async () => {
+      const callOrder: string[] = [];
+      setWindowProperty.mockImplementation(() => {
+        callOrder.push('setWindowProperty');
+        return Promise.resolve();
+      });
+      mockPage.goto.mockImplementation(() => {
+        callOrder.push('goto');
+        return Promise.resolve({
+          ok: () => true,
+          statusText: () => 'OK',
+        });
+      });
+
+      await previewPdf(TEST_URL);
+
+      const swpIndex = callOrder.indexOf('setWindowProperty');
+      const gotoIndex = callOrder.indexOf('goto');
+      expect(swpIndex).toBeGreaterThanOrEqual(0);
+      expect(gotoIndex).toBeGreaterThanOrEqual(0);
+      expect(swpIndex).toBeLessThan(gotoIndex);
+    });
+  });
+
+  describe('status check ordering', () => {
+    it('checks page status BEFORE generating PDF', async () => {
+      const callOrder: string[] = [];
+      mockPage.goto.mockImplementation(() => {
+        callOrder.push('goto');
+        return Promise.resolve({
+          ok: () => false,
+          statusText: () => 'Internal Server Error',
+        });
+      });
+      mockPage.pdf.mockImplementation(() => {
+        callOrder.push('pdf');
+        return Promise.resolve(Buffer.from(''));
+      });
+
+      await expect(previewPdf(TEST_URL)).rejects.toThrow();
+
+      expect(callOrder).toContain('goto');
+      expect(callOrder).not.toContain('pdf');
+    });
+  });
+
+  describe('no hardcoded delays', () => {
+    it('does not use setTimeout/delay before network idle', async () => {
+      const originalSetTimeout = global.setTimeout;
+      const timeoutSpy = jest.spyOn(global, 'setTimeout');
+
+      await previewPdf(TEST_URL);
+
+      const delayishCalls = timeoutSpy.mock.calls.filter(
+        ([, ms]) => typeof ms === 'number' && ms >= 500,
+      );
+      expect(delayishCalls).toHaveLength(0);
+
+      timeoutSpy.mockRestore();
+      global.setTimeout = originalSetTimeout;
+    });
+  });
+
+  describe('successful preview', () => {
+    it('returns PDF buffer directly', async () => {
+      const expectedBuffer = Buffer.from('%PDF-mock');
+      mockPage.pdf.mockResolvedValue(expectedBuffer);
+
+      const result = await previewPdf(TEST_URL);
+
+      expect(result).toEqual(expectedBuffer);
+    });
+
+    it('sets viewport dimensions', async () => {
+      await previewPdf(TEST_URL);
+
+      expect(mockPage.setViewport).toHaveBeenCalledWith({
+        width: 1024,
+        height: 768,
+      });
+    });
+
+    it('generates A4 PDF with headers and footers', async () => {
+      await previewPdf(TEST_URL);
+
+      expect(mockPage.pdf).toHaveBeenCalledWith(
+        expect.objectContaining({
+          format: 'a4',
+          printBackground: true,
+          displayHeaderFooter: true,
+          headerTemplate: '<div>header</div>',
+          footerTemplate: '<div>footer</div>',
+          margin: { top: '54px', bottom: '54px' },
+        }),
+      );
+    });
+
+    it('navigates with networkidle2', async () => {
+      await previewPdf(TEST_URL);
+
+      expect(mockPage.goto).toHaveBeenCalledWith(
+        TEST_URL,
+        expect.objectContaining({ waitUntil: 'networkidle2' }),
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws on non-ok page response', async () => {
+      mockPage.goto.mockResolvedValue({
+        ok: () => false,
+        statusText: () => 'Not Found',
+      });
+
+      await expect(previewPdf(TEST_URL)).rejects.toThrow();
+    });
+
+    it('throws on null page response', async () => {
+      mockPage.goto.mockResolvedValue(null);
+
+      await expect(previewPdf(TEST_URL)).rejects.toThrow();
+    });
+  });
+});

--- a/src/browser/previewPDF.ts
+++ b/src/browser/previewPDF.ts
@@ -1,89 +1,70 @@
-import puppeteer from 'puppeteer';
-import {
-  CHROMIUM_PATH,
-  pageHeight,
-  pageWidth,
-  setWindowProperty,
-} from './helpers';
-import config from '../common/config';
+import type { Page } from 'puppeteer';
+import { pageHeight, pageWidth, setWindowProperty } from './helpers';
 import { getHeaderAndFooterTemplates } from '../server/render-template';
 import { apiLogger } from '../common/logging';
+import { cluster } from '../server/cluster';
 
-function delay(time: number) {
-  return new Promise(function (resolve) {
-    setTimeout(resolve, time);
-  });
-}
-
-const previewPdf = async (url: string) => {
-  const createBuffer = async () => {
-    const browser = await puppeteer.launch({
-      headless: true,
-      ...(config?.IS_PRODUCTION
-        ? {
-            // we have a different dir structure than puppeteer expects. We have to point it to the correct chromium executable
-            executablePath: CHROMIUM_PATH,
-          }
-        : {}),
-      args: ['--no-sandbox', '--disable-gpu'],
-    });
-    const page = await browser.newPage();
-
-    // Enables console logging in Headless mode - handy for debugging components
-    page.on('console', (msg) =>
-      apiLogger.debug(`[Headless log] ${msg.text()}`),
-    );
-    await page.setViewport({ width: pageWidth, height: pageHeight });
-    const extraHeaders: Record<string, string> = {};
-    if (process.env.MOCK_TOKEN) {
-      extraHeaders['Authorization'] = process.env.MOCK_TOKEN;
-    }
-    await page.setCookie({ name: 'cs_jwt', value: 'bar', domain: 'localhost' });
-    await page.setExtraHTTPHeaders(extraHeaders);
-
-    const pageStatus = await page.goto(url, {
-      waitUntil: 'networkidle2',
-    });
-
-    await delay(1000);
-    await page.waitForNetworkIdle();
-    const { headerTemplate, footerTemplate } = getHeaderAndFooterTemplates();
-
-    await setWindowProperty(
-      page,
-      'customPuppeteerParams',
-      JSON.stringify({
-        puppeteerParams: {
-          pageWidth,
-          pageHeight,
-        },
-      }),
-    );
-
-    const pdfBuffer = await page.pdf({
-      format: 'a4',
-      printBackground: true,
-      displayHeaderFooter: true,
-      headerTemplate,
-      footerTemplate,
-      margin: {
-        top: '54px',
-        bottom: '54px',
-      },
-    });
-
-    if (!pageStatus?.ok()) {
-      throw new Error(
-        `Puppeteer error while loading the react app: ${pageStatus?.statusText()}`,
+const previewPdf = async (url: string): Promise<Buffer> =>
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  cluster.execute(async ({ page }: { page: Page }) => {
+    try {
+      page.on('console', (msg) =>
+        apiLogger.debug(`[Headless log] ${msg.text()}`),
       );
+      await page.setViewport({ width: pageWidth, height: pageHeight });
+
+      await setWindowProperty(
+        page,
+        'customPuppeteerParams',
+        JSON.stringify({
+          puppeteerParams: {
+            pageWidth,
+            pageHeight,
+          },
+        }),
+      );
+
+      const extraHeaders: Record<string, string> = {};
+      if (process.env.MOCK_TOKEN) {
+        extraHeaders['Authorization'] = process.env.MOCK_TOKEN;
+      }
+      await page.setCookie({
+        name: 'cs_jwt',
+        value: 'bar',
+        domain: 'localhost',
+      });
+      await page.setExtraHTTPHeaders(extraHeaders);
+
+      const pageStatus = await page.goto(url, {
+        waitUntil: 'networkidle2',
+      });
+
+      if (!pageStatus?.ok()) {
+        throw new Error(
+          `Puppeteer error while loading the react app: ${pageStatus?.statusText()}`,
+        );
+      }
+
+      const { headerTemplate, footerTemplate } = getHeaderAndFooterTemplates();
+
+      return await page.pdf({
+        format: 'a4',
+        printBackground: true,
+        displayHeaderFooter: true,
+        headerTemplate,
+        footerTemplate,
+        margin: {
+          top: '54px',
+          bottom: '54px',
+        },
+      });
+    } finally {
+      try {
+        await page.close();
+      } catch {
+        // page may already be closed
+      }
     }
-
-    await browser.close();
-    return pdfBuffer;
-  };
-
-  const bufferLock = createBuffer();
-  return await bufferLock;
-};
+  });
 
 export default previewPdf;


### PR DESCRIPTION
## Summary

- Rewrites `previewPDF.ts` to use the shared puppeteer-cluster (`cluster.execute()`) instead of launching a standalone Chromium process per preview request
- Fixes 5 bugs: `setWindowProperty` called after `goto`, status check after PDF generation, hardcoded 1s delay, missing `--disable-dev-shm-usage`, standalone browser overhead
- Adds 10 unit tests covering cluster integration, call ordering, delay absence, output contract, and error handling

[RHCLOUD-48979](https://issues.redhat.com/browse/RHCLOUD-48979)

---

### How to test locally

1. `npm test` — all 127 tests pass (13 suites)
2. `npm run lint` — clean
3. `npm run circular` — no circular deps
4. Manual: `npm run start:server` → `GET /preview?url=...` → returns PDF

---

### Anything reviewers should know?

- Preview now shares the cluster concurrency queue with PDF generation. Under heavy generation load, preview requests may wait. This is intentional — standalone browser consumed resources outside the pool.
- Pre-existing: hardcoded `cs_jwt=bar` cookie (line 31-34) was carried over from old code. Likely a dev stub — worth a follow-up to clean up.
- `page.close()` in `finally` matches `clusterTask.ts` pattern.

---

### Checklist
- [x] Tests: new/updated tests cover the change
- [x] API: spec updated if endpoints changed (or N/A)
- [x] Migrations: backwards compatible if schema changed (or N/A)
- [x] Dependencies: no known impact to dependent services
- [x] Security: reviewed against [secure coding checklist](https://github.com/RedHatInsights/secure-coding-checklist) (or N/A)

### AI disclosure
Assisted by: Claude Code, Cursor Composer 2.5

[RHCLOUD-48979]: https://redhat.atlassian.net/browse/RHCLOUD-48979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ