### PR TITLE
fix: consolidate LOG_LEVEL handling across Winston and KafkaJS

### DIFF
--- a/src/browser/tokenRefresh.spec.ts
+++ b/src/browser/tokenRefresh.spec.ts
@@ -24,7 +24,7 @@ jest.mock('../common/logging', () => ({
   apiLogger: {
     debug: jest.fn(),
     error: jest.fn(),
-    warn: jest.fn(),
+    warning: jest.fn(),
   },
 }));
 
@@ -240,7 +240,7 @@ describe('TokenManager', () => {
 
     const result = await tm.getValidToken();
     expect(result).toBe(token);
-    expect(apiLogger.warn).toHaveBeenCalledWith(
+    expect(apiLogger.warning).toHaveBeenCalledWith(
       '[token-refresh] Transient failure, proceeding with expiring token',
     );
   });

--- a/src/browser/tokenRefresh.ts
+++ b/src/browser/tokenRefresh.ts
@@ -101,7 +101,7 @@ export class TokenManager {
             );
             return null;
           } else if (result && result.error === 'transient') {
-            apiLogger.warn(
+            apiLogger.warning(
               '[token-refresh] Transient failure, proceeding with expiring token',
             );
           }

--- a/src/common/kafka.ts
+++ b/src/common/kafka.ts
@@ -94,7 +94,6 @@ const kafkaLogCreator =
     const message = `[${namespace}] ${log.message}`;
     switch (level) {
       case kafkaLogLevel.ERROR:
-      case kafkaLogLevel.NOTHING:
         apiLogger.error(message);
         break;
       case kafkaLogLevel.WARN:

--- a/src/common/kafka.ts
+++ b/src/common/kafka.ts
@@ -1,4 +1,9 @@
-import { Kafka, SASLOptions } from 'kafkajs';
+import {
+  Kafka,
+  SASLOptions,
+  logLevel as kafkaLogLevel,
+  type LogEntry,
+} from 'kafkajs';
 import config from '../common/config';
 import { apiLogger } from './logging';
 import PdfCache, { PDFComponent } from './pdfCache';
@@ -64,6 +69,51 @@ export const getKafkaSASL = (brokers: KafkaBroker[]) => {
   return undefined;
 };
 
+const mapSyslogLevelToKafkaLogLevel = (syslogLevel: string): kafkaLogLevel => {
+  switch (syslogLevel) {
+    case 'emerg':
+    case 'alert':
+    case 'crit':
+    case 'error':
+      return kafkaLogLevel.ERROR;
+    case 'warning':
+    case 'notice':
+      return kafkaLogLevel.WARN;
+    case 'info':
+      return kafkaLogLevel.INFO;
+    case 'debug':
+      return kafkaLogLevel.DEBUG;
+    default:
+      return kafkaLogLevel.INFO;
+  }
+};
+
+const kafkaLogCreator =
+  () =>
+  ({ namespace, level, log }: LogEntry) => {
+    const message = `[${namespace}] ${log.message}`;
+    switch (level) {
+      case kafkaLogLevel.ERROR:
+      case kafkaLogLevel.NOTHING:
+        apiLogger.error(message);
+        break;
+      case kafkaLogLevel.WARN:
+        apiLogger.warning(message);
+        break;
+      case kafkaLogLevel.INFO:
+        apiLogger.info(message);
+        break;
+      case kafkaLogLevel.DEBUG:
+        apiLogger.debug(message);
+        break;
+    }
+  };
+
+const kafkaLoggingOptions = {
+  logLevel: mapSyslogLevelToKafkaLogLevel(config?.LOG_LEVEL ?? 'info'),
+  logCreator: kafkaLogCreator,
+};
+
 const KafkaClient = () => {
   const brokers = config?.kafka.brokers;
   const sasl = getKafkaSASL(brokers);
@@ -75,6 +125,7 @@ const KafkaClient = () => {
       brokers: kafkaSocketAddresses(brokers),
       ssl: ssl,
       sasl: sasl,
+      ...kafkaLoggingOptions,
     });
   }
   apiLogger.debug('no ssl');
@@ -82,6 +133,7 @@ const KafkaClient = () => {
     clientId: 'crc-pdf-gen',
     brokers: kafkaSocketAddresses(brokers),
     ssl: false,
+    ...kafkaLoggingOptions,
   });
 };
 

--- a/src/common/logging.ts
+++ b/src/common/logging.ts
@@ -47,13 +47,16 @@ export const hpmLogger = winston.createLogger({
  * requestLogger is exclusively responsible for logging requests from express.
  */
 export const requestLogger = expressWinston.logger({
-  level: config?.LOG_LEVEL,
-  transports: [new winston.transports.Console()],
+  winstonInstance: winston.createLogger({
+    levels: logLevels,
+    level: config?.LOG_LEVEL,
+    transports: [new winston.transports.Console()],
+    format: winston.format.combine(
+      winston.format.timestamp(),
+      winston.format.json(),
+    ),
+  }),
   requestWhitelist: ['url', 'method', 'httpVersion', 'originalUrl', 'query'],
-  format: winston.format.combine(
-    winston.format.timestamp(),
-    winston.format.json(),
-  ),
   meta: false,
   msg: 'HTTP {{req.method}} {{res.statusCode}} {{req.url}}',
   skip: SendVerboseLogs


### PR DESCRIPTION
## Summary

- **requestLogger**: pass `winstonInstance` with syslog levels to express-winston so `LOG_LEVEL=warning` no longer triggers `[winston] Unknown logger level: warning`
- **KafkaJS**: add `logLevel` mapping from syslog strings and `logCreator` that routes KafkaJS logs through `apiLogger`, so `LOG_LEVEL` env var controls Kafka log verbosity
- **tokenRefresh**: fix `.warn()` → `.warning()` to match syslog-level logger API

## Behavior change

Request logs now emit at `info` level (express-winston default) instead of being forced to whatever `LOG_LEVEL` is set to. With `LOG_LEVEL=warning` in prod, HTTP request access logs are suppressed — this is correct semantics (request logs are informational, not warnings). Previously they were emitted at `warning`/`error` level which was semantically wrong.

## Test plan

- [x] `npm run build:production` — compiles clean
- [x] `npm test` — 117 tests pass
- [x] `npm run lint` — clean
- [x] `npm run circular` — no circular deps
- [ ] Deploy to ephemeral with `LOG_LEVEL=warning` and verify no `[winston] Unknown logger level` stderr
- [ ] Verify KafkaJS logs respect `LOG_LEVEL` setting

Resolves [RHCLOUD-49106](https://issues.redhat.com/browse/RHCLOUD-49106)

---

[RHCLOUD-49106]: https://redhat.atlassian.net/browse/RHCLOUD-49106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ